### PR TITLE
append __NOEDITSECTION__ to tabber body before parsing

### DIFF
--- a/includes/TabberNeueHooks.php
+++ b/includes/TabberNeueHooks.php
@@ -68,7 +68,9 @@ class TabberNeueHooks {
 		// Use array_pad to make sure at least 2 array values are always returned
 		list( $tabName, $tabBody ) = array_pad( explode( '=', $tab, 2 ), 2, '' );
 
-		$tabBody = $parser->recursiveTagParseFully( $tabBody, $frame );
+		// Append __NOEDITSECTION__ to prevent section edit links from being added by the parser
+		// since section edit links do not work inside a tabber body
+		$tabBody = $parser->recursiveTagParseFully( '__NOEDITSECTION__' . $tabBody, $frame );
 
 		$tab = '<article class="tabber__panel" title="' . htmlspecialchars( $tabName ) .
 			'">' . $tabBody . '</article>';


### PR DESCRIPTION
Since edit section links do not work when inside a tabber body, i suggest adding `__NOEDITSECTION__ ` to the tab body before it's getting parsed so the parser will never add them.