### PR TITLE
fix for DOMException caused by invalid selector

### DIFF
--- a/modules/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue.js
@@ -196,7 +196,7 @@ function initTabber( tabber, count ) {
 		let targetHash = new mw.Uri( location.href ).fragment;
 
 		// Switch to the first tab if no targetHash or no tab is detected
-		if ( !targetHash || !document.getElementById( 'tab-' + targetHash ) ) {
+		if ( !targetHash || !tabList.querySelector( '#tab-' + CSS.escape( targetHash ) ) ) {
 			targetHash = tabList.firstElementChild.getAttribute( 'id' ).substring( 4 );
 		}
 

--- a/modules/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue.js
@@ -196,7 +196,7 @@ function initTabber( tabber, count ) {
 		let targetHash = new mw.Uri( location.href ).fragment;
 
 		// Switch to the first tab if no targetHash or no tab is detected
-		if ( !targetHash || !tabList.querySelector( '#tab-' + targetHash ) ) {
+		if ( !targetHash || !document.getElementById( 'tab-' + targetHash ) ) {
 			targetHash = tabList.firstElementChild.getAttribute( 'id' ).substring( 4 );
 		}
 


### PR DESCRIPTION
If a tab name contains special characters, it causes the tab hash to contain `.`. When trying to use the tab hash in a selector, it causes this error: `DOMException: Element.querySelector: '<tabname>' is not a valid selector`.