### PR TITLE
fix tabs sometimes not rendering after a refresh

### DIFF
--- a/modules/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue.js
@@ -374,4 +374,4 @@ function main() {
 	}
 }
 
-main();
+$(document).ready(main);


### PR DESCRIPTION
Hi,

I have a page that contains tabs, and each tab has quite a lot of templates, etc. going on inside it.

What I am observing is that when I refresh the page or preview it, sometimes only the first tab renders. See the attached video here:

https://user-images.githubusercontent.com/37142182/171100206-4715dfa1-7d40-41a3-8f7f-74c8a85f3fd0.mp4

After some debugging, I think this occurs when the `ext.tabberNeue.js` file is cached by the browser. This causes a race condition where sometimes the `main` function of `ext.tabberNeue.js` runs before the page has fully rendered. 

I changed line 377 of `ext.tabberNeue.js` from `main()` to `$(document).ready(main)` and this seems to fix the issue.
