### PR TITLE
Revert back to recursiveTagParse()

### DIFF
--- a/includes/Tabber.php
+++ b/includes/Tabber.php
@@ -88,7 +88,7 @@ class Tabber {
 		list( $tabName, $tabBody ) = array_pad( explode( '=', $tab, 2 ), 2, '' );
 
 		$tabName = trim( $tabName );
-		$tabBody = $parser->recursiveTagParseFully( $tabBody, $frame );
+		$tabBody = $parser->recursiveTagParse( $tabBody, $frame );
 
 		$tab = '<article class="tabber__panel" title="' . htmlspecialchars( $tabName ) .
 			'">' . $tabBody . '</article>';

--- a/includes/Tabber.php
+++ b/includes/Tabber.php
@@ -80,14 +80,14 @@ class Tabber {
 	 * @return string HTML
 	 */
 	private static function buildTab( $tab, Parser $parser, PPFrame $frame ) {
-		$tab = trim( $tab );
-		if ( empty( $tab ) ) {
-			return $tab;
+		if ( empty( trim( $tab ) ) ) {
+			return '';
 		}
 
 		// Use array_pad to make sure at least 2 array values are always returned
-		list( $tabName, $tabBody ) = array_pad( array_map( 'trim', explode( '=', $tab, 2 ) ), 2, '' );
+		list( $tabName, $tabBody ) = array_pad( explode( '=', $tab, 2 ), 2, '' );
 
+		$tabName = trim( $tabName );
 		$tabBody = $parser->recursiveTagParseFully( $tabBody, $frame );
 
 		$tab = '<article class="tabber__panel" title="' . htmlspecialchars( $tabName ) .

--- a/includes/TabberParsoid.php
+++ b/includes/TabberParsoid.php
@@ -55,14 +55,14 @@ class TabberParsoid extends ExtensionTagHandler {
 	 * @return string HTML
 	 */
 	private static function buildTab( ParsoidExtensionAPI $extApi, string $tab ) {
-		$tab = trim( $tab );
-		if ( empty( $tab ) ) {
-			return $tab;
+		if ( empty( trim( $tab ) ) ) {
+			return '';
 		}
 
 		// Use array_pad to make sure at least 2 array values are always returned
-		list( $tabName, $tabBody ) = array_pad( array_map( 'trim', explode( '=', $tab, 2 ) ), 2, '' );
+		list( $tabName, $tabBody ) = array_pad( explode( '=', $tab, 2 ), 2, '' );
 
+		$tabName = trim( $tabName );
 		$tabBody = $extApi->domToHTML(
 				$extApi->wikitextToDOM(
 					$tabBody,

--- a/includes/TabberTransclude.php
+++ b/includes/TabberTransclude.php
@@ -85,8 +85,7 @@ class TabberTransclude {
 	 * @return string HTML
 	 */
 	private static function buildTabTransclude( $tab, Parser $parser, PPFrame $frame, &$selected ) {
-		$tab = trim( $tab );
-		if ( empty( $tab ) ) {
+		if ( empty( trim( $tab ) ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5573780/172042738-e9411433-adae-4ce8-b554-24f3a08a0820.png)
recursiveTagParseFully() is _extremely expensive_ on unstrip size when tabbers are nested. Reverting back to recursiveTagParse() should shave about half of the unstrip size. This change have a side effect of increasing recursion depth count, but at 20 there should be plenty available compared to the almost exponential unstrip size growth.

The trim behavior also should make whitespace handling to be more similar to how it works on wikitext table syntax. This also should fix issue #3 without resorting to full parsing. Adding newline before the very first list should be enough (again, just like table).

I don't have enough use case on tabberTransclude to do proper test if similar change is okay.