### PR TITLE
fix: one pixel offset on tab panels

### DIFF
--- a/modules/ext.tabberNeue.less
+++ b/modules/ext.tabberNeue.less
@@ -90,10 +90,6 @@
 
 	&__header,
 	&__section {
-		/* prevent scroll chaining on x scroll */
-		overscroll-behavior-x: contain;
-		/* scrolling should snap children on x */
-		scroll-snap-type: x mandatory;
 		scrollbar-width: none;
 
 		&::-webkit-scrollbar {
@@ -108,7 +104,6 @@
 		padding: 0.5em 0.75em;
 		color: #54595d;
 		font-weight: bold;
-		scroll-snap-align: start;
 		text-decoration: none;
 		white-space: nowrap;
 
@@ -131,8 +126,7 @@
 
 	&__panel {
 		height: max-content;
-		overflow-y: auto;
-		scroll-snap-align: start;
+		overflow-x: auto;
 
 		// Hide edit buttons for non-transclusion tabs since they don't work
 		/* stylelint-disable-next-line selector-class-pattern */


### PR DESCRIPTION
Since __header and __section cannot be scrolled manually, "overscroll-behavior" and "scroll-snap" are not needed at all.

With `scroll-snap-type: x mandatory` and `scroll-snap-align: start` declared, when elements' width are float numbers, web explorer will force tab panels to be offset by 0.0-1.0 pixels, which would result in the tab panels going out of bound by 1 pixel sometimes in Chrome or other explorers.