### PR TITLE
Fix issue where disabling TabberNeueEnableAnimation didn't actually work

### DIFF
--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -25,8 +25,8 @@ class TabberAction {
 	 */
 	static shouldShowAnimation() {
 		return (
-			!window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ||
-            !config.enableAnimation
+			!window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches &&
+            config.enableAnimation
 		);
 	}
 


### PR DESCRIPTION
Setting `$wgTabberNeueEnableAnimation = false;` doesn't actually do anything in the current version of TabberNeue.

This is because `shouldShowAnimation()` is checking whether the user **has not** enabled reduced motion **or** `config.enableAnimation` is not true. The second condition check is short-circuited because the first (effectively whether reduced motion is NOT enabled) is `true`, so the function always returns `true`.

Instead, we should check whether reduced motion is not enabled **and** whether `config.enableAnimation` is true.