### PR TITLE
Ensure that the active tab is set before the tabber event is initialized

### DIFF
--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -211,9 +211,9 @@ class TabberAction {
 					activeTab.parentElement
 				);
 				TabberAction.setActiveTabpanel( activeTabpanel, currentActiveTabpanel );
-			} );
 
-			resolve();
+				resolve();
+			} );
 		} );
 	}
 
@@ -646,14 +646,12 @@ class TabberBuilder {
 		await this.createIndicator();
 
 		const activeTab = this.tablist.querySelector( `#tab-${ CSS.escape( urlHash ) }` ) || this.tablist.firstElementChild;
-		TabberAction.setActiveTab( activeTab );
+		await TabberAction.setActiveTab( activeTab );
 		TabberAction.updateHeaderOverflow( this.tablist );
 
 		// Start attaching event
-		setTimeout( () => {
-			const tabberEvent = new TabberEvent( this.tabber, this.tablist );
-			tabberEvent.init();
-		}, 0 );
+		const tabberEvent = new TabberEvent( this.tabber, this.tablist );
+		tabberEvent.init();
 
 		this.tabber.classList.add( 'tabber--live' );
 	}


### PR DESCRIPTION
On page load there is a race condition between the window.requestAnimationFrame in setActiveTab and the setTimeout in init(), and if the timeout runs first, the active tab will not have been set yet, causing a console error and causing the tabs to not work as intended.
Another alternative would be adding a longer timeout but that feels like a bandaid fix, however if for some reason the animation frame callback is not called, it would not resolve in this case. Maybe the active tab could be set outside of the callback.

This bug is still happening in 2.4.0