### PR TITLE
fix: keep arrow button icon inside its parent

### DIFF
--- a/modules/ext.tabberNeue/ext.tabberNeue.less
+++ b/modules/ext.tabberNeue/ext.tabberNeue.less
@@ -72,10 +72,9 @@
 			cursor: pointer;
 
 			&::after {
-				position: absolute;
-				top: 0;
-				bottom: 0;
+				display: block;
 				width: inherit;
+				height: 100%;
 				background-position: center;
 				background-repeat: no-repeat;
 				background-size: 14px;


### PR DESCRIPTION
I noticed that the `::after` arrow icon elements have auto `left: 10px; right: -10px` offset when a tabber is put inside an infobox. The parent `<button>` somehow has `text-align: center`, and the quirk is explained in the commit message. Anyway removing the `position: absolute` solves the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced visual styling for the tabber component, including new color variables and improved button styles.
	- Added animations for loading states and a skeleton loading effect for better user experience.

- **Bug Fixes**
	- Improved visibility and transition effects for the tab indicator and navigation buttons.

- **Style**
	- Refined media queries for responsive hover effects and updated print styles to optimize content display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->