### PR TITLE
Fix "Optional parameter $args declared before required parameter $frame is implicitly treated as a required parameter"

### DIFF
--- a/includes/Tabber.php
+++ b/includes/Tabber.php
@@ -75,7 +75,7 @@ class Tabber {
 	 *
 	 * @return string HTML
 	 */
-	public static function render( string $input, int $count, array $args = [], Parser $parser, PPFrame $frame ): string {
+	public static function render( string $input, int $count, array $args, Parser $parser, PPFrame $frame ): string {
 		$arr = explode( '|-|', $input );
 		$data = [
 			'id' => isset( $args['id'] ) ? $args['id'] : "tabber-$count",

--- a/includes/TabberTransclude.php
+++ b/includes/TabberTransclude.php
@@ -69,7 +69,7 @@ class TabberTransclude {
 	 *
 	 * @return string HTML
 	 */
-	public static function render( string $input, int $count, array $args = [], Parser $parser, PPFrame $frame ): string {
+	public static function render( string $input, int $count, array $args, Parser $parser, PPFrame $frame ): string {
 		$selected = true;
 		$arr = explode( "\n", $input );
 		$data = [


### PR DESCRIPTION
> Deprecated: Optional parameter $args declared before required parameter $frame is implicitly treated as a required parameter in /srv/mediawiki/1.43/extensions/TabberNeue/includes/Tabber.php on line 78

> Deprecated: Optional parameter $args declared before required parameter $frame is implicitly treated as a required parameter in /srv/mediawiki/1.43/extensions/TabberNeue/includes/TabberTransclude.php on line 72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated method signatures in the `Tabber` and `TabberTransclude` classes to require an `$args` parameter for the `render` method.
  
- **Bug Fixes**
	- Ensured consistency in method invocation by enforcing the provision of the `$args` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->