### PR TITLE
Fix "trim(): Argument #1 ($string) must be of type string, null given"

### DIFF
--- a/includes/TabberTransclude.php
+++ b/includes/TabberTransclude.php
@@ -146,7 +146,7 @@ class TabberTransclude {
 		$pageName = $tabData['content'] ?? '';
 
 		$dataProps = [];
-		$title = Title::newFromText( trim( $pageName  ) );
+		$title = Title::newFromText( trim( $pageName ) );
 		if ( !$title ) {
 			if ( empty( $tabName ) ) {
 				$tabName = $pageName;

--- a/includes/TabberTransclude.php
+++ b/includes/TabberTransclude.php
@@ -143,10 +143,10 @@ class TabberTransclude {
 	 */
 	private static function buildTabTransclude( array $tabData, Parser $parser, PPFrame $frame, bool &$selected ): string {
 		$tabName = $tabData['label'];
-		$pageName = $tabData['content'];
+		$pageName = $tabData['content'] ?? '';
 
 		$dataProps = [];
-		$title = Title::newFromText( trim( $pageName ) );
+		$title = Title::newFromText( trim( $pageName  ) );
 		if ( !$title ) {
 			if ( empty( $tabName ) ) {
 				$tabName = $pageName;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in tab content processing to prevent potential undefined index errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->