### PR TITLE
Fix for percent-encoded fragments not changing tab on load and the hashchange event not working

### DIFF
--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -424,7 +424,8 @@ class TabberBuilder {
 		if ( !urlHash ) {
 			return activeTab;
 		}
-		const escapedHash = mw.util.escapeIdForAttribute( urlHash );
+		const decodedHash = mw.util.percentDecodeFragment( urlHash );
+		const escapedHash = mw.util.escapeIdForAttribute( decodedHash );
 		const idFromUrlHash = escapedHash.replace( 'tabber-tabpanel-', 'tabber-tab-' );
 		if ( idFromUrlHash === escapedHash ) {
 			return activeTab;
@@ -485,7 +486,10 @@ async function load( tabberEls ) {
 		TabberAction.toggleAnimation( true );
 		window.addEventListener( 'hashchange', ( event ) => {
 			const hash = window.location.hash.slice( 1 );
-			const tab = document.getElementById( `tabber-tab-${ CSS.escape( hash ) }` );
+			const decodedHash = mw.util.percentDecodeFragment( hash )
+			const escapedHash = mw.util.escapeIdForAttribute( decodedHash );
+			const idFromUrlHash = escapedHash.replace( 'tabber-tabpanel-', 'tabber-tab-' );
+			const tab = document.getElementById( idFromUrlHash );
 			if ( tab ) {
 				event.preventDefault();
 				tab.click();

--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -486,7 +486,7 @@ async function load( tabberEls ) {
 		TabberAction.toggleAnimation( true );
 		window.addEventListener( 'hashchange', ( event ) => {
 			const hash = window.location.hash.slice( 1 );
-			const decodedHash = mw.util.percentDecodeFragment( hash )
+			const decodedHash = mw.util.percentDecodeFragment( hash );
 			const escapedHash = mw.util.escapeIdForAttribute( decodedHash );
 			const idFromUrlHash = escapedHash.replace( 'tabber-tabpanel-', 'tabber-tab-' );
 			const tab = document.getElementById( idFromUrlHash );


### PR DESCRIPTION
Fix for #209 by passing the fragment first through [mw.util.percentDecodeFragment](https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.percentDecodeFragment).

Also fixes the `hashchange` event to even work, in it's current form it never works since it appends `tabber-tab-` onto the fragment instead of replacing `tabber-tabpanel-`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL hash handling for tab navigation.
	- Enhanced decoding of percent-encoded characters in URL hashes.
	- Ensured more robust tab selection based on URL state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->