### PR TITLE
fix: double encoding of htmlspecialchars for plain text tab labels

### DIFF
--- a/includes/Tabber.php
+++ b/includes/Tabber.php
@@ -197,7 +197,7 @@ class Tabber {
 			// plain text label has already been passed through 'htmlspecialchars' in 'convertHtml' of 'getTabLabel'
 			$id = Sanitizer::escapeIdForAttribute( $label );
 		} else {
-			$id = Sanitizer::escapeIdForAttribute( $label );
+			$id = Sanitizer::escapeIdForAttribute( htmlspecialchars( $label ) );
 		}
 
 		if ( self::$useLegacyId === true ) {

--- a/includes/Tabber.php
+++ b/includes/Tabber.php
@@ -193,7 +193,12 @@ class Tabber {
 			$content = Html::rawElement( 'p', [], $content );
 		}
 
-		$id = Sanitizer::escapeIdForAttribute( htmlspecialchars( $label ) );
+		if ( !self::$parseTabName ) {
+			// plain text label has already been passed through 'htmlspecialchars' in 'convertHtml' of 'getTabLabel'
+			$id = Sanitizer::escapeIdForAttribute( $label );
+		} else {
+			$id = Sanitizer::escapeIdForAttribute( $label );
+		}
 
 		if ( self::$useLegacyId === true ) {
 			$parserOutput = $parser->getOutput();


### PR DESCRIPTION
Fix for the other part of #209, issue could be closed now.

Since `convertHtml` during the execution of `getTabLabel` already passed that tab label through htmlspecialchars, passing it through it again gives unexpected results. The call should be kept for wikitext labels though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved tab ID generation logic to handle different parsing configurations more accurately
	- Enhanced sanitization process for tab labels and IDs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->