### PR TITLE
fix: ResizeObserver not adjusting after tab change

### DIFF
--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -281,7 +281,9 @@ class TabberEvent {
 			// Prevent default anchor actions
 			e.preventDefault();
 			this.activeTab = tab;
+			resizeObserver.unobserve( this.activeTabpanel );
 			this.activeTabpanel = TabberAction.getTabpanel( this.activeTab );
+			resizeObserver.observe( this.activeTabpanel );
 
 			// Update the URL hash without adding to browser history
 			if ( config.updateLocationOnTabChange ) {


### PR DESCRIPTION
Fix for #208.

Not sure if this the 100% correct place to adjust the resize observer, but it certainly works without problems in my testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved tab panel resize event handling to ensure accurate tracking of the active tab's panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->