### PR TITLE
fix: tabs not being selected with fragments that contain unescaped html special chars

### DIFF
--- a/modules/ext.tabberNeue/Util.js
+++ b/modules/ext.tabberNeue/Util.js
@@ -72,17 +72,32 @@ class Util {
 	}
 
 	/**
-	 * Transforms the fragment indentifier to the expected element id of the tab header.
+	 * Selects the element of the tab header matching the fragment identifier.
 	 *
 	 * @param {String} urlHash - URL fragment identifier (URL hash with '#' already removed).
-	 * @return {String} Element id of the tab header.
+	 * @return {Element} The element of the matching tab header.
 	 */
-	static getElementIdFromUrlHash( urlHash ) {
+	static selectElementFromUrlHash( urlHash ) {
 		const decodedHash = mw.util.percentDecodeFragment( urlHash );
 		const escapedHash = mw.util.escapeIdForAttribute( decodedHash );
-		const specialCharEscapedHash = mw.html.escape( escapedHash );
-		const idFromUrlHash = specialCharEscapedHash.replace( 'tabber-tabpanel-', 'tabber-tab-' );
-		return idFromUrlHash;
+		const idFromUrlHash = escapedHash.replace( 'tabber-tabpanel-', 'tabber-tab-' );
+		let activeTabFromUrlHash = document.getElementById( idFromUrlHash );
+
+		if ( !activeTabFromUrlHash ) {
+			// Retry getting the tab after escaping html special chars to correctly select
+			// the tab for cases where the fragment does not use the escaped version
+			const specialCharEscapedHash = mw.html.escape( idFromUrlHash );
+			activeTabFromUrlHash = document.getElementById( specialCharEscapedHash );
+
+			if( !activeTabFromUrlHash ) {
+				return;
+			}
+		}
+
+		// Ensures that only tabber elements are selected
+		if( activeTabFromUrlHash.classList.contains( 'tabber__tab' ) ) {
+			return activeTabFromUrlHash;
+		}
 	}
 }
 

--- a/modules/ext.tabberNeue/Util.js
+++ b/modules/ext.tabberNeue/Util.js
@@ -75,7 +75,7 @@ class Util {
 	 * Transforms the fragment indentifier to the expected element id of the tab header.
 	 *
 	 * @param {String} urlHash - URL fragment identifier (URL hash with '#' already removed).
-	 * @return {String} - Element id of the tab header.
+	 * @return {String} Element id of the tab header.
 	 */
 	static getElementIdFromUrlHash( urlHash ) {
 		const decodedHash = mw.util.percentDecodeFragment( urlHash );

--- a/modules/ext.tabberNeue/Util.js
+++ b/modules/ext.tabberNeue/Util.js
@@ -78,7 +78,7 @@ class Util {
 	 * @return {Element} The element of the matching tab header.
 	 */
 	static selectElementFromUrlHash( urlHash ) {
-		if( !urlHash ) {
+		if ( !urlHash ) {
 			return;
 		}
 		const decodedHash = mw.util.percentDecodeFragment( urlHash );
@@ -92,13 +92,13 @@ class Util {
 			const specialCharEscapedHash = mw.html.escape( idFromUrlHash );
 			activeTabFromUrlHash = document.getElementById( specialCharEscapedHash );
 
-			if( !activeTabFromUrlHash ) {
+			if ( !activeTabFromUrlHash ) {
 				return;
 			}
 		}
 
 		// Ensures that only tabber elements are selected
-		if( activeTabFromUrlHash.classList.contains( 'tabber__tab' ) ) {
+		if ( activeTabFromUrlHash.classList.contains( 'tabber__tab' ) ) {
 			return activeTabFromUrlHash;
 		}
 	}

--- a/modules/ext.tabberNeue/Util.js
+++ b/modules/ext.tabberNeue/Util.js
@@ -78,6 +78,9 @@ class Util {
 	 * @return {Element} The element of the matching tab header.
 	 */
 	static selectElementFromUrlHash( urlHash ) {
+		if( !urlHash ) {
+			return;
+		}
 		const decodedHash = mw.util.percentDecodeFragment( urlHash );
 		const escapedHash = mw.util.escapeIdForAttribute( decodedHash );
 		const idFromUrlHash = escapedHash.replace( 'tabber-tabpanel-', 'tabber-tab-' );

--- a/modules/ext.tabberNeue/Util.js
+++ b/modules/ext.tabberNeue/Util.js
@@ -70,6 +70,20 @@ class Util {
 			element.setAttribute( key, attributes[ key ] );
 		}
 	}
+
+	/**
+	 * Transforms the fragment indentifier to the expected element id of the tab header.
+	 *
+	 * @param {String} urlHash - URL fragment identifier (URL hash with '#' already removed).
+	 * @return {String} - Element id of the tab header.
+	 */
+	static getElementIdFromUrlHash( urlHash ) {
+		const decodedHash = mw.util.percentDecodeFragment( urlHash );
+		const escapedHash = mw.util.escapeIdForAttribute( decodedHash );
+		const specialCharEscapedHash = mw.html.escape( escapedHash );
+		const idFromUrlHash = specialCharEscapedHash.replace( 'tabber-tabpanel-', 'tabber-tab-' );
+		return idFromUrlHash;
+	}
 }
 
 module.exports = Util;

--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -426,11 +426,7 @@ class TabberBuilder {
 		if ( !urlHash ) {
 			return activeTab;
 		}
-		const idFromUrlHash = Util.getElementIdFromUrlHash( urlHash );
-		if ( idFromUrlHash === escapedHash ) {
-			return activeTab;
-		}
-		const activeTabFromUrlHash = document.getElementById( idFromUrlHash );
+		const activeTabFromUrlHash = Util.selectElementFromUrlHash( urlHash );
 		if ( !activeTabFromUrlHash ) {
 			return activeTab;
 		}
@@ -486,8 +482,7 @@ async function load( tabberEls ) {
 		TabberAction.toggleAnimation( true );
 		window.addEventListener( 'hashchange', ( event ) => {
 			const hash = window.location.hash.slice( 1 );
-			const idFromUrlHash = Util.getElementIdFromUrlHash( hash );
-			const tab = document.getElementById( idFromUrlHash );
+			const tab = Util.selectElementFromUrlHash( hash );
 			if ( tab ) {
 				event.preventDefault();
 				tab.click();

--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -426,9 +426,7 @@ class TabberBuilder {
 		if ( !urlHash ) {
 			return activeTab;
 		}
-		const decodedHash = mw.util.percentDecodeFragment( urlHash );
-		const escapedHash = mw.util.escapeIdForAttribute( decodedHash );
-		const idFromUrlHash = escapedHash.replace( 'tabber-tabpanel-', 'tabber-tab-' );
+		const idFromUrlHash = Util.getElementIdFromUrlHash( urlHash );
 		if ( idFromUrlHash === escapedHash ) {
 			return activeTab;
 		}
@@ -488,9 +486,7 @@ async function load( tabberEls ) {
 		TabberAction.toggleAnimation( true );
 		window.addEventListener( 'hashchange', ( event ) => {
 			const hash = window.location.hash.slice( 1 );
-			const decodedHash = mw.util.percentDecodeFragment( hash );
-			const escapedHash = mw.util.escapeIdForAttribute( decodedHash );
-			const idFromUrlHash = escapedHash.replace( 'tabber-tabpanel-', 'tabber-tab-' );
+			const idFromUrlHash = Util.getElementIdFromUrlHash( hash );
 			const tab = document.getElementById( idFromUrlHash );
 			if ( tab ) {
 				event.preventDefault();


### PR DESCRIPTION
#209 fix once again and should *really* be the last one.

Fragments containing unescaped special chars like `'` instead of `&#039;` are not selected. I just added a retry when selecting the tab element with the escaped version if the first try failed. Checking whether its already escaped would be much more complex so this should be good enough.

I've also moved the fragment transformation and element selection into a util function and added a check to make sure the selected element is generated by tabber (the previous code, at least in the hashchange event part, would trigger for any hashchange and could trigger the click event on any element).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new utility method to select tab elements based on URL hash.

- **Refactor**
	- Simplified tab selection logic in the TabberBuilder.
	- Consolidated URL hash processing into a more streamlined utility function.
	- Improved code maintainability by reducing redundant hash processing steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->