### PR TITLE
fix: incorrect tabber id counts with nested tabbers

### DIFF
--- a/includes/Tabber.php
+++ b/includes/Tabber.php
@@ -52,10 +52,9 @@ class Tabber {
 		self::$useLegacyId = $config->get( 'TabberNeueUseLegacyTabIds' );
 
 		$count = count( $parserOutput->getExtensionData( 'tabber-count' ) ?? [] );
+		$parserOutput->appendExtensionData( 'tabber-count', ++$count );
 
 		$html = self::render( $input, $count, $args, $parser, $frame );
-
-		$parserOutput->appendExtensionData( 'tabber-count', ++$count );
 
 		$parserOutput->addModuleStyles( [ 'ext.tabberNeue.init.styles' ] );
 		$parserOutput->addModules( [ 'ext.tabberNeue' ] );

--- a/includes/Tabber.php
+++ b/includes/Tabber.php
@@ -52,7 +52,7 @@ class Tabber {
 		self::$useLegacyId = $config->get( 'TabberNeueUseLegacyTabIds' );
 
 		$count = count( $parserOutput->getExtensionData( 'tabber-count' ) ?? [] );
-		$parserOutput->appendExtensionData( 'tabber-count', ++$count );
+		$parserOutput->appendExtensionData( 'tabber-count', $count + 1 );
 
 		$html = self::render( $input, $count, $args, $parser, $frame );
 


### PR DESCRIPTION
Fix for the first issue in #207.

Tabber count is updated after `render`, but during `render`, `recursiveTagParse` is called. With nested tabbers, this causes the first nested one to use the still unupdated count, which it then shares with the parent tabber.