### PR TITLE
Bump MW requirement to 1.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The TabberNeue extension allows wikis to create tabs within a page. It is a fork
 [Extension:TabberNeue on MediaWiki](https://www.mediawiki.org/wiki/Extension:TabberNeue).
 
 ## Requirements
-* [MediaWiki](https://www.mediawiki.org) 1.39 or later
+* [MediaWiki](https://www.mediawiki.org) 1.43 or later
 
 ## Installation
 You can get the extension via Git (specifying TabberNeue as the destination directory):

--- a/extension.json
+++ b/extension.json
@@ -60,10 +60,6 @@
 			],
 			"dependencies": [
 				"mediawiki.util"
-			],
-			"targets": [
-				"desktop",
-				"mobile"
 			]
 		},
 		"ext.tabberNeue.visualEditor": {
@@ -91,10 +87,6 @@
 				"tabberneue-visualeditor-mwtabberdialog-desc",
 				"tabberneue-visualeditor-mwtabbertranscludeinspector-title",
 				"tabberneue-visualeditor-mwtabbertranscludeinspector-desc"
-			],
-			"targets": [
-				"desktop",
-				"mobile"
 			]
 		},
 		"ext.tabberNeue.icons": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "TabberNeue",
-	"version": "2.7.4",
+	"version": "3.0.0-alpha",
 	"author": [
 		"alistair3149",
 		"Eric Fortin",
@@ -12,7 +12,7 @@
 	"type": "parserhook",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.39.0"
+		"MediaWiki": ">= 1.43.0"
 	},
 	"MessagesDirs": {
 		"TabberNeue": [

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -5,16 +5,13 @@ declare( strict_types=1 );
 namespace MediaWiki\Extension\TabberNeue;
 
 use MediaWiki\Hook\ParserFirstCallInitHook;
-use OutputPage;
-use Parser;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Parser\Parser;
 use Skin;
 
 class Hooks implements ParserFirstCallInitHook {
 	/**
 	 * @see https://www.mediawiki.org/wiki/Extension:MobileFrontend/BeforePageDisplayMobile
-	 *
-	 * @param OutputPage $out
-	 * @param Skin $sk
 	 */
 	public static function onBeforePageDisplayMobile( OutputPage $out, Skin $sk ) {
 		$out->addModuleStyles( [ 'ext.tabberNeue.mobile.styles' ] );

--- a/includes/Tabber.php
+++ b/includes/Tabber.php
@@ -14,13 +14,13 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Extension\TabberNeue;
 
-use Html;
 use InvalidArgumentException;
+use MediaWiki\Html\TemplateParser;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
-use Parser;
-use PPFrame;
-use Sanitizer;
-use TemplateParser;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\PPFrame;
+use MediaWiki\Parser\Sanitizer;
 
 class Tabber {
 
@@ -32,15 +32,8 @@ class Tabber {
 
 	/**
 	 * Parser callback for <tabber> tag
-	 *
-	 * @param string|null $input
-	 * @param array $args
-	 * @param Parser $parser Mediawiki Parser Object
-	 * @param PPFrame $frame Mediawiki PPFrame Object
-	 *
-	 * @return string HTML
 	 */
-	public static function parserHook( ?string $input, array $args, Parser $parser, PPFrame $frame ) {
+	public static function parserHook( ?string $input, array $args, Parser $parser, PPFrame $frame ): string {
 		if ( $input === null ) {
 			return '';
 		}
@@ -65,14 +58,6 @@ class Tabber {
 
 	/**
 	 * Renders the necessary HTML for a <tabber> tag.
-	 *
-	 * @param string $input The input URL between the beginning and ending tags.
-	 * @param int $count Current Tabber count
-	 * @param array $args
-	 * @param Parser $parser Mediawiki Parser Object
-	 * @param PPFrame $frame Mediawiki PPFrame Object
-	 *
-	 * @return string HTML
 	 */
 	public static function render( string $input, int $count, array $args, Parser $parser, PPFrame $frame ): string {
 		$attr = [
@@ -110,11 +95,6 @@ class Tabber {
 
 	/**
 	 * Get parsed tab labels
-	 *
-	 * @param string $label tab label wikitext
-	 * @param Parser $parser Mediawiki Parser Object
-	 *
-	 * @return string
 	 */
 	private static function getTabLabel( string $label, Parser $parser ): string {
 		$label = trim( $label );
@@ -136,12 +116,6 @@ class Tabber {
 
 	/**
 	 * Get parsed tab content
-	 *
-	 * @param string $content tab content wikitext
-	 * @param Parser $parser Mediawiki Parser Object
-	 * @param PPFrame $frame Mediawiki PPFrame Object
-	 *
-	 * @return string
 	 */
 	private static function getTabContent( string $content, Parser $parser, PPFrame $frame ): string {
 		$content = trim( $content );
@@ -162,12 +136,6 @@ class Tabber {
 	/**
 	 * Get individual tab data from wikitext.
 	 *
-	 * @param string $tab tab wikitext
-	 * @param int $count Current Tabber count
-	 * @param Parser $parser Mediawiki Parser Object
-	 * @param PPFrame $frame Mediawiki PPFrame Object
-	 *
-	 * @return array
 	 * @throws MWException
 	 */
 	private static function getTabData( string $tab, int $count, Parser $parser, PPFrame $frame ): array {

--- a/includes/Tabber.php
+++ b/includes/Tabber.php
@@ -15,8 +15,8 @@ declare( strict_types=1 );
 namespace MediaWiki\Extension\TabberNeue;
 
 use InvalidArgumentException;
-use MediaWiki\Html\TemplateParser;
 use MediaWiki\Html\Html;
+use MediaWiki\Html\TemplateParser;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;

--- a/includes/TabberTransclude.php
+++ b/includes/TabberTransclude.php
@@ -15,12 +15,12 @@ declare( strict_types=1 );
 namespace MediaWiki\Extension\TabberNeue;
 
 use Exception;
+use MediaWiki\Html\TemplateParser;
 use MediaWiki\MediaWikiServices;
-use Parser;
-use PPFrame;
-use Sanitizer;
-use TemplateParser;
-use Title;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\PPFrame;
+use MediaWiki\Parser\Sanitizer;
+use MediaWiki\Title\Title;
 
 class TabberTransclude {
 
@@ -29,15 +29,8 @@ class TabberTransclude {
 
 	/**
 	 * Parser callback for <tabbertransclude> tag
-	 *
-	 * @param string|null $input
-	 * @param array $args
-	 * @param Parser $parser Mediawiki Parser Object
-	 * @param PPFrame $frame Mediawiki PPFrame Object
-	 *
-	 * @return string HTML
 	 */
-	public static function parserHook( ?string $input, array $args, Parser $parser, PPFrame $frame ) {
+	public static function parserHook( ?string $input, array $args, Parser $parser, PPFrame $frame ): string {
 		if ( $input === null ) {
 			return '';
 		}
@@ -62,14 +55,6 @@ class TabberTransclude {
 
 	/**
 	 * Renders the necessary HTML for a <tabbertransclude> tag.
-	 *
-	 * @param string $input The input URL between the beginning and ending tags.
-	 * @param int $count Current Tabber count
-	 * @param array $args
-	 * @param Parser $parser Mediawiki Parser Object
-	 * @param PPFrame $frame Mediawiki PPFrame Object
-	 *
-	 * @return string HTML
 	 */
 	public static function render( string $input, int $count, array $args, Parser $parser, PPFrame $frame ): string {
 		$selected = true;
@@ -116,10 +101,6 @@ class TabberTransclude {
 
 	/**
 	 * Get individual tab data from wikitext.
-	 *
-	 * @param string $tab tab wikitext
-	 *
-	 * @return array
 	 */
 	private static function getTabData( string $tab ): array {
 		if ( empty( trim( $tab ) ) ) {
@@ -146,12 +127,6 @@ class TabberTransclude {
 	/**
 	 * Build individual tab.
 	 *
-	 * @param array $tabData Tab data
-	 * @param Parser $parser Mediawiki Parser Object
-	 * @param PPFrame $frame Mediawiki PPFrame Object
-	 * @param bool &$selected The tab is the selected one
-	 *
-	 * @return string HTML
 	 * @throws Exception
 	 */
 	private static function buildTabTransclude( array $tabData, Parser $parser, PPFrame $frame, bool &$selected ): string {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the minimum required MediaWiki version to 1.43 in the README.
- **Chores**
  - Increased the extension version to 3.0.0-alpha and raised the minimum MediaWiki requirement to 1.43.0.
  - Updated internal dependencies and platform targeting for resource modules.
- **Refactor**
  - Improved code quality by updating namespace imports and removing redundant type annotations.
  - Explicitly typed method return values for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->