### PR TITLE
Fix for clicking next/prev buttons saving the current edit

### DIFF
--- a/includes/templates/Tabs.mustache
+++ b/includes/templates/Tabs.mustache
@@ -6,7 +6,7 @@
 				}}<a class="tabber__tab" role="tab"{{#array-tab-attributes}} {{key}}="{{{value}}}"{{/array-tab-attributes}}>{{{label}}}</a>{{!
 			}}{{/array-tabs}}{{!
 		}}</nav>{{!
-		}}<button class="tabber__header__next" type="button" tabindex="-1" aria-hidden="true"></button>{{!
+		}}<button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button>{{!
 	}}</header>{{!
 
 	}}<section class="tabber__section">{{!

--- a/includes/templates/Tabs.mustache
+++ b/includes/templates/Tabs.mustache
@@ -1,12 +1,12 @@
 <div {{#array-attributes}} {{key}}="{{{value}}}"{{/array-attributes}}>{{!
 	}}<header class="tabber__header">{{!
-		}}<button class="tabber__header__prev" tabindex="-1" aria-hidden="true"></button>{{!
+		}}<button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button>{{!
 		}}<nav class="tabber__tabs" role="tablist">{{!
 			}}{{#array-tabs}}{{!
 				}}<a class="tabber__tab" role="tab"{{#array-tab-attributes}} {{key}}="{{{value}}}"{{/array-tab-attributes}}>{{{label}}}</a>{{!
 			}}{{/array-tabs}}{{!
 		}}</nav>{{!
-		}}<button class="tabber__header__next" tabindex="-1" aria-hidden="true"></button>{{!
+		}}<button class="tabber__header__next" type="button" tabindex="-1" aria-hidden="true"></button>{{!
 	}}</header>{{!
 
 	}}<section class="tabber__section">{{!


### PR DESCRIPTION
This fixes the edit being saved when the prev/next buttons are clicked in the side-by-side edit preview; as the edit window is a form element, these being buttons will submit the form when clicked (i.e. saving the edit). Adding this attribute prevents this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated tab navigation buttons to explicitly specify their type, preventing unintended form submissions and ensuring consistent button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->