### PR TITLE
fix: tabs with url-encoded characters not being selected through url fragment

### DIFF
--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -572,7 +572,7 @@ class TabberController {
 			return;
 		}
 
-		const decodedUrlHash = mw.util.percentDecodeFragment( urlHash );
+		const decodedUrlHash = mw.util.percentDecodeFragment( hash );
 		const targetElement = document.getElementById( decodedUrlHash );
 		if ( targetElement === null ) {
 			return;

--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -150,7 +150,8 @@ class Tabber {
 		}
 
 		// The hash can be an ID of a panel or an element within a panel.
-		const targetElement = document.getElementById( urlHash );
+		const decodedUrlHash = mw.util.percentDecodeFragment( urlHash );
+		const targetElement = document.getElementById( decodedUrlHash );
 		if ( targetElement === null ) {
 			return defaultTab;
 		}
@@ -571,7 +572,8 @@ class TabberController {
 			return;
 		}
 
-		const targetElement = document.getElementById( hash );
+		const decodedUrlHash = mw.util.percentDecodeFragment( urlHash );
+		const targetElement = document.getElementById( decodedUrlHash );
 		if ( targetElement === null ) {
 			return;
 		}

--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -149,9 +149,10 @@ class Tabber {
 			return defaultTab;
 		}
 
-		// The hash can be an ID of a panel or an element within a panel.
-		const decodedUrlHash = mw.util.percentDecodeFragment( urlHash );
-		const targetElement = document.getElementById( decodedUrlHash );
+		// percentDecodeFragment is needded for #209
+		const targetElement = document.getElementById(
+			mw.util.percentDecodeFragment( hash )
+		);
 		if ( targetElement === null ) {
 			return defaultTab;
 		}
@@ -572,8 +573,10 @@ class TabberController {
 			return;
 		}
 
-		const decodedUrlHash = mw.util.percentDecodeFragment( hash );
-		const targetElement = document.getElementById( decodedUrlHash );
+		// percentDecodeFragment is needded for #209
+		const targetElement = document.getElementById(
+			mw.util.percentDecodeFragment( hash )
+		);
 		if ( targetElement === null ) {
 			return;
 		}

--- a/modules/ext.tabberNeue/ext.tabberNeue.js
+++ b/modules/ext.tabberNeue/ext.tabberNeue.js
@@ -151,7 +151,7 @@ class Tabber {
 
 		// percentDecodeFragment is needded for #209
 		const targetElement = document.getElementById(
-			mw.util.percentDecodeFragment( hash )
+			mw.util.percentDecodeFragment( urlHash )
 		);
 		if ( targetElement === null ) {
 			return defaultTab;


### PR DESCRIPTION
Fixes #246.

Interestingly, the tab is changed during the hashchange event, even though `handleHashChange` doesn't work with url-encoded fragments, because `handlePanelIntersection` is triggered during the hashchange, which also sets the active tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of URL hash fragments with special characters, ensuring tabs are correctly activated even when the hash contains percent-encoded characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->