### PR TITLE
feat: opt-in tab wrapping mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ Awesome third tab content goes here.
 ### Tab wrapping
 By default, when the tab headers are wider than the available space they stay on a single row that scrolls horizontally, with previous/next arrows. You can instead let the tabs **wrap** onto multiple rows.
 
-Enable it wiki-wide by setting `$wgTabberNeueEnableTabWrap = true;` (see [Configurations](#configurations)), or control it per tabber with the `wrap` attribute. The attribute always overrides the wiki-wide default:
+Enable it wiki-wide by setting `$wgTabberNeueEnableTabWrap = true;` (see [Configurations](#configurations)), or control it per tabber with the `wrap` attribute, which always overrides the wiki-wide default:
 ```html
-<tabber wrap>
+<tabber wrap=true>
 |-|First Tab Title=
 First tab content goes here.
 |-|Second Tab Title=
@@ -127,7 +127,7 @@ First tab content goes here.
 Second tab content goes here.
 </tabber>
 ```
-The `wrap` attribute works on `<tabbertransclude>` as well. Accepted values: `wrap`, `wrap=true`, `wrap=yes` enable; `wrap=false`, `wrap=no`, `wrap=off`, `wrap=0` disable.
+The `wrap` attribute also works on `<tabbertransclude>`. (A bare `<tabber wrap>` is accepted as shorthand for `wrap=true`.)
 
 ### Lua
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,29 @@ Awesome third tab content goes here.
 </tabber>
 ```
 
+### Tab wrapping
+By default, when the tab headers are wider than the available space they stay on a single row that scrolls horizontally, with previous/next arrows. You can instead let the tabs **wrap** onto multiple rows.
+
+Enable it wiki-wide by setting `$wgTabberNeueEnableTabWrap = true;` (see [Configurations](#configurations)), or control it per tabber with the `wrap` attribute. The attribute always overrides the wiki-wide default:
+```html
+<tabber wrap>
+|-|First Tab Title=
+First tab content goes here.
+|-|Second Tab Title=
+Second tab content goes here.
+</tabber>
+```
+To force a single tabber back to scrolling when wrapping is enabled wiki-wide, use `wrap=false`:
+```html
+<tabber wrap=false>
+|-|First Tab Title=
+First tab content goes here.
+|-|Second Tab Title=
+Second tab content goes here.
+</tabber>
+```
+The `wrap` attribute works on `<tabbertransclude>` as well. Accepted values: `wrap`, `wrap=true`, `wrap=yes` enable; `wrap=false`, `wrap=no`, `wrap=off`, `wrap=0` disable.
+
 ### Lua
 
 Tabber can be invoked in Lua with the `mw.ext.tabber` library. For example:
@@ -137,6 +160,7 @@ Name | Description | Values | Default
 `$wgTabberNeueParseTabName` | Parse tab name as wikitext. This can have a performance impact and cause unexpected behaviors. |`true` - enable; `false` - disable | `false`
 `$wgTabberNeueUpdateLocationOnTabChange` | If enabled, when a tab is selected, the URL displayed on the browser changes. Opening this URL makes that tab initially selected |`true` - enable; `false` - disable | `true`
 `$wgTabberNeueAddTabPrefix` | If enabled, tabpanel IDs will be prepended with "tabber-" to avoid conflicts with page headings. |`true` - enable; `false` - disable | `true`
+`$wgTabberNeueEnableTabWrap` | If enabled, tab headers wrap onto multiple rows instead of a horizontally-scrollable row. Can be overridden per tabber with the `wrap` attribute. |`true` - enable; `false` - disable | `false`
 
 #### Tracking category
 TabberNeue adds a tracking category to all pages using Tabber for maintenance purposes. There are two ways to suppress the category from viewers:

--- a/extension.json
+++ b/extension.json
@@ -169,6 +169,11 @@
 			"value": true,
 			"description": "If enabled, tabpanel IDs will be prepended with \"tabber-\". This avoids potential conflicts with page headings that use the same IDs.",
 			"public": true
+		},
+		"TabberNeueEnableTabWrap": {
+			"value": false,
+			"description": "If enabled, tab headers wrap onto multiple rows instead of using a horizontally-scrollable overflow container. Can be overridden per-tag with the `wrap` attribute (e.g. <tabber wrap> or <tabber wrap=false>).",
+			"public": true
 		}
 	},
 	"Hooks": {

--- a/includes/Components/TabberComponentTabs.php
+++ b/includes/Components/TabberComponentTabs.php
@@ -8,13 +8,18 @@ use MediaWiki\Parser\Sanitizer;
 class TabberComponentTabs implements TabberComponent {
 	public function __construct(
 		private array $tabsData,
-		private array $additionalAttributes
+		private array $additionalAttributes,
+		private bool $wrap = false
 	) {
 	}
 
 	private function getAttributes(): array {
+		$class = 'tabber tabber--init';
+		if ( $this->wrap ) {
+			$class .= ' tabber--wrap';
+		}
 		$attributes = [
-			'class' => 'tabber tabber--init'
+			'class' => $class
 		];
 
 		foreach ( $this->additionalAttributes as $attribute => $value ) {

--- a/includes/Hook/ParserTestGlobalsHandler.php
+++ b/includes/Hook/ParserTestGlobalsHandler.php
@@ -31,6 +31,9 @@ class ParserTestGlobalsHandler implements ParserTestGlobalsHook {
 			$services->resetServiceForTesting( 'TabberNeue.TabParser' );
 			$services->resetServiceForTesting( 'TabberNeue.TabIdRegistry' );
 			$services->resetServiceForTesting( 'TabberNeue.TabModelBuilder' );
+			// TabberRenderer reads wgTabberNeueEnableTabWrap at construction, so it
+			// must be reset before the handlers that depend on it pick it up.
+			$services->resetServiceForTesting( 'TabberNeue.TabberRenderer' );
 			$services->resetServiceForTesting( 'TabberNeue.TabberHandler' );
 			$services->resetServiceForTesting( 'TabberNeue.TabberTranscludeHandler' );
 			// HookContainer caches hook handler objects (including the Hooks class

--- a/includes/Service/TabberRenderer.php
+++ b/includes/Service/TabberRenderer.php
@@ -12,8 +12,24 @@ use MediaWiki\Parser\Parser;
 class TabberRenderer {
 
 	public function __construct(
-		private readonly TemplateParser $templateParser
+		private readonly TemplateParser $templateParser,
+		private readonly bool $enableTabWrap = false
 	) {
+	}
+
+	/**
+	 * Resolve whether wrap mode is active: a per-tag `wrap` attribute overrides
+	 * the wiki-wide default. A bare `<tabber wrap>` (empty value) enables it.
+	 */
+	public static function resolveTabWrap( array $args, bool $default ): bool {
+		if ( !array_key_exists( 'wrap', $args ) ) {
+			return $default;
+		}
+		$value = strtolower( trim( (string)$args['wrap'] ) );
+		if ( $value === '' ) {
+			return true;
+		}
+		return !in_array( $value, [ 'false', '0', 'no', 'off' ], true );
 	}
 
 	/**
@@ -31,6 +47,11 @@ class TabberRenderer {
 			return '';
 		}
 
+		$wrap = self::resolveTabWrap( $args, $this->enableTabWrap );
+		// `wrap` is not a valid div attribute; strip it so it does not leak into
+		// the rendered markup (and would otherwise be dropped by validateTagAttributes).
+		unset( $args['wrap'] );
+
 		$parserOutput = $parser->getOutput();
 		$parserOutput->addModuleStyles( [ 'ext.tabberNeue.init.styles' ] );
 		$parserOutput->addModules( [ 'ext.tabberNeue' ] );
@@ -46,7 +67,7 @@ class TabberRenderer {
 			$tabsData[] = $tab->getTemplateData();
 		}
 
-		$tabs = new TabberComponentTabs( $tabsData, $args );
+		$tabs = new TabberComponentTabs( $tabsData, $args, $wrap );
 
 		return $this->templateParser->processTemplate( 'Tabs', $tabs->getTemplateData() );
 	}

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -36,7 +36,8 @@ return [
 	},
 	'TabberNeue.TabberRenderer' => static function ( MediaWikiServices $services ): TabberRenderer {
 		return new TabberRenderer(
-			new TemplateParser( __DIR__ . '/templates' )
+			new TemplateParser( __DIR__ . '/templates' ),
+			(bool)$services->getMainConfig()->get( 'TabberNeueEnableTabWrap' )
 		);
 	},
 	'TabberNeue.TabSegmentSplitter' => static function (): TabSegmentSplitter {

--- a/modules/ext.tabberNeue.init/ext.tabberNeue.init.less
+++ b/modules/ext.tabberNeue.init/ext.tabberNeue.init.less
@@ -75,6 +75,17 @@
 	}
 }
 
+// Wrap mode: tabs flow onto multiple rows instead of a scrollable row.
+// Server-rendered class, so this lives in critical CSS to avoid layout shift.
+// Higher specificity than `.tabber__tabs { overflow: auto hidden }` above, so
+// it wins without !important. Prev/next arrows and edge masks are driven by
+// `--prev/next-visible`, which never get set when there is no horizontal
+// overflow, so they stay hidden automatically.
+.tabber--wrap .tabber__tabs {
+	flex-wrap: wrap;
+	overflow: visible;
+}
+
 // Basic nojs support
 /* stylelint-disable-next-line selector-class-pattern */
 .client-nojs {

--- a/modules/ext.tabberNeue/createOverflowController.js
+++ b/modules/ext.tabberNeue/createOverflowController.js
@@ -8,6 +8,11 @@ const OVERFLOW_BUTTON_WIDTH_RATIO = 0.2;
  * @property {HTMLElement} tablist
  * @property {HTMLElement} header
  * @property {boolean} [animationsEnabled=true]
+ * @property {boolean} [enabled=true] When false, the controller never reports
+ *   overflow and never shows the prev/next arrows or edge masks. Used in wrap
+ *   mode, where a single tab wider than the container still produces horizontal
+ *   overflow (tabs are `white-space: nowrap`) but the arrows are meaningless
+ *   because the tablist is not scrollable (`overflow: visible`).
  * @property {Function} [raf]
  *
  * @typedef {Object} OverflowController
@@ -27,6 +32,7 @@ function createOverflowController( opts ) {
 	const tablist = opts.tablist;
 	const header = opts.header;
 	const animationsEnabled = opts.animationsEnabled !== false;
+	const enabled = opts.enabled !== false;
 	const raf = opts.raf || window.requestAnimationFrame.bind( window );
 	let overflowing = false;
 
@@ -46,6 +52,16 @@ function createOverflowController( opts ) {
 	}
 
 	function update( metrics ) {
+		if ( !enabled ) {
+			// Wrap mode: never show arrows/masks even when an over-wide tab
+			// causes horizontal overflow, since the tablist is not scrollable.
+			overflowing = false;
+			header.classList.remove(
+				'tabber__header--prev-visible',
+				'tabber__header--next-visible'
+			);
+			return;
+		}
 		const m = metrics || getMetrics();
 		overflowing = overflowMath.isOverflowing( m );
 		if ( !overflowing ) {

--- a/modules/ext.tabberNeue/createTabIndicator.js
+++ b/modules/ext.tabberNeue/createTabIndicator.js
@@ -8,6 +8,9 @@
  * @typedef {Object} TabIndicatorOpts
  * @property {HTMLElement} tablist
  * @property {Document} [document]
+ * @property {boolean} [enabled=true] When false, no indicator is created and
+ *   update/destroy are no-ops, letting the per-tab box-shadow underline show
+ *   (used in wrap mode where a single sliding indicator can't span rows).
  *
  * @typedef {Object} TabIndicator
  * @property {Function} update
@@ -21,6 +24,10 @@
 function createTabIndicator( opts ) {
 	const tablist = opts.tablist;
 	const doc = opts.document || document;
+
+	if ( opts.enabled === false ) {
+		return { update() {}, destroy() {} };
+	}
 
 	const element = doc.createElement( 'span' );
 	element.className = 'tabber__indicator';

--- a/modules/ext.tabberNeue/createTabber.js
+++ b/modules/ext.tabberNeue/createTabber.js
@@ -83,7 +83,8 @@ function createTabber( opts ) {
 	// which are declared as hoisted function declarations and are only *called*
 	// after the units are assigned.
 	const units = {};
-	units.tabIndicator = createTabIndicator( { tablist, document: doc } );
+	const isWrap = element.classList.contains( 'tabber--wrap' );
+	units.tabIndicator = createTabIndicator( { tablist, document: doc, enabled: !isWrap } );
 	units.panelTransition = createPanelTransition( { document: doc } );
 	units.vt = createViewTransitionWrapper( { section, document: doc } );
 

--- a/modules/ext.tabberNeue/createTabber.js
+++ b/modules/ext.tabberNeue/createTabber.js
@@ -173,7 +173,7 @@ function createTabber( opts ) {
 
 	// Compose units
 	units.overflow = createOverflowController( {
-		tablist, header, animationsEnabled, raf
+		tablist, header, animationsEnabled, raf, enabled: !isWrap
 	} );
 	const debouncedUpdateOverflow = mwApi.util.debounce(
 		() => units.overflow.update(), 100

--- a/tests/parser/tabberneue.txt
+++ b/tests/parser/tabberneue.txt
@@ -260,6 +260,20 @@ wgTabberNeueAddTabPrefix=true
 !! end
 
 !! test
+TabberNeue: tabbertransclude honours the wrap attribute
+!! config
+wgTabberNeueParseTabName=false
+wgTabberNeueAddTabPrefix=true
+wgTabberNeueEnableTabWrap=false
+!! wikitext
+<tabbertransclude wrap>
+TabberNeue test/Does Not Exist|First
+</tabbertransclude>
+!! html
+<div class="tabber tabber--init tabber--wrap"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><div class="cdx-message cdx-message--block cdx-message--error"><span class="cdx-message__icon"></span><div class="cdx-message__content">Page does not exist: TabberNeue test/Does Not Exist</div></div></article></section></div>
+!! end
+
+!! test
 TabberNeue: wrap attribute enables tabber--wrap with config default off
 !! config
 wgTabberNeueParseTabName=false
@@ -267,6 +281,29 @@ wgTabberNeueAddTabPrefix=true
 wgTabberNeueEnableTabWrap=false
 !! wikitext
 <tabber wrap>
+|-|First=
+First content.
+|-|Second=
+Second content.
+</tabber>
+!! html
+<div class="tabber tabber--init tabber--wrap"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
+</p><p>First content.
+</p>
+<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
+</p><p>Second content.
+</p>
+<p class="mw-empty-elt"></p></article></section></div>
+!! end
+
+!! test
+TabberNeue: config default on adds tabber--wrap without a wrap attribute
+!! config
+wgTabberNeueParseTabName=false
+wgTabberNeueAddTabPrefix=true
+wgTabberNeueEnableTabWrap=true
+!! wikitext
+<tabber>
 |-|First=
 First content.
 |-|Second=

--- a/tests/parser/tabberneue.txt
+++ b/tests/parser/tabberneue.txt
@@ -260,20 +260,6 @@ wgTabberNeueAddTabPrefix=true
 !! end
 
 !! test
-TabberNeue: tabbertransclude honours the wrap attribute
-!! config
-wgTabberNeueParseTabName=false
-wgTabberNeueAddTabPrefix=true
-wgTabberNeueEnableTabWrap=false
-!! wikitext
-<tabbertransclude wrap>
-TabberNeue test/Does Not Exist|First
-</tabbertransclude>
-!! html
-<div class="tabber tabber--init tabber--wrap"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><div class="cdx-message cdx-message--block cdx-message--error"><span class="cdx-message__icon"></span><div class="cdx-message__content">Page does not exist: TabberNeue test/Does Not Exist</div></div></article></section></div>
-!! end
-
-!! test
 TabberNeue: wrap attribute enables tabber--wrap with config default off
 !! config
 wgTabberNeueParseTabName=false

--- a/tests/parser/tabberneue.txt
+++ b/tests/parser/tabberneue.txt
@@ -258,3 +258,49 @@ wgTabberNeueAddTabPrefix=true
 </tabbertransclude>
 !! html
 !! end
+
+!! test
+TabberNeue: wrap attribute enables tabber--wrap with config default off
+!! config
+wgTabberNeueParseTabName=false
+wgTabberNeueAddTabPrefix=true
+wgTabberNeueEnableTabWrap=false
+!! wikitext
+<tabber wrap>
+|-|First=
+First content.
+|-|Second=
+Second content.
+</tabber>
+!! html
+<div class="tabber tabber--init tabber--wrap"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
+</p><p>First content.
+</p>
+<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
+</p><p>Second content.
+</p>
+<p class="mw-empty-elt"></p></article></section></div>
+!! end
+
+!! test
+TabberNeue: wrap=false attribute overrides config default on
+!! config
+wgTabberNeueParseTabName=false
+wgTabberNeueAddTabPrefix=true
+wgTabberNeueEnableTabWrap=true
+!! wikitext
+<tabber wrap=false>
+|-|First=
+First content.
+|-|Second=
+Second content.
+</tabber>
+!! html
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
+</p><p>First content.
+</p>
+<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
+</p><p>Second content.
+</p>
+<p class="mw-empty-elt"></p></article></section></div>
+!! end

--- a/tests/phpunit/Integration/Components/TabberComponentTabsTest.php
+++ b/tests/phpunit/Integration/Components/TabberComponentTabsTest.php
@@ -75,4 +75,24 @@ class TabberComponentTabsTest extends MediaWikiIntegrationTestCase {
 
 		$this->assertSame( $tabsData, $tabs->getTemplateData()['array-tabs'] );
 	}
+
+	/**
+	 * @covers ::getTemplateData
+	 */
+	public function testWrapClassAddedWhenEnabled(): void {
+		$tabs = new TabberComponentTabs( [], [], true );
+
+		$attrs = $this->asAssoc( $tabs->getTemplateData()['array-attributes'] );
+		$this->assertStringContainsString( 'tabber--wrap', $attrs['class'] );
+	}
+
+	/**
+	 * @covers ::getTemplateData
+	 */
+	public function testWrapClassAbsentByDefault(): void {
+		$tabs = new TabberComponentTabs( [], [] );
+
+		$attrs = $this->asAssoc( $tabs->getTemplateData()['array-attributes'] );
+		$this->assertStringNotContainsString( 'tabber--wrap', $attrs['class'] );
+	}
 }

--- a/tests/phpunit/Unit/Service/TabberRendererTest.php
+++ b/tests/phpunit/Unit/Service/TabberRendererTest.php
@@ -1,0 +1,37 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\TabberNeue\Tests\Unit\Service;
+
+use MediaWiki\Extension\TabberNeue\Service\TabberRenderer;
+use MediaWikiUnitTestCase;
+
+/**
+ * @group TabberNeue
+ * @coversDefaultClass \MediaWiki\Extension\TabberNeue\Service\TabberRenderer
+ */
+class TabberRendererTest extends MediaWikiUnitTestCase {
+
+	/**
+	 * @covers ::resolveTabWrap
+	 * @dataProvider provideWrapArgs
+	 */
+	public function testResolveTabWrap( array $args, bool $default, bool $expected ): void {
+		$this->assertSame( $expected, TabberRenderer::resolveTabWrap( $args, $default ) );
+	}
+
+	public static function provideWrapArgs(): array {
+		return [
+			'no arg, default off' => [ [], false, false ],
+			'no arg, default on' => [ [], true, true ],
+			'bare wrap' => [ [ 'wrap' => '' ], false, true ],
+			'wrap=true' => [ [ 'wrap' => 'true' ], false, true ],
+			'wrap=yes' => [ [ 'wrap' => 'yes' ], false, true ],
+			'wrap=false overrides default on' => [ [ 'wrap' => 'false' ], true, false ],
+			'wrap=no' => [ [ 'wrap' => 'no' ], true, false ],
+			'wrap=0' => [ [ 'wrap' => '0' ], true, false ],
+			'wrap=off' => [ [ 'wrap' => 'off' ], true, false ],
+			'mixed case WRAP=False' => [ [ 'wrap' => 'False' ], true, false ],
+		];
+	}
+}

--- a/tests/vitest/ext.tabberNeue/createOverflowController.test.js
+++ b/tests/vitest/ext.tabberNeue/createOverflowController.test.js
@@ -50,6 +50,22 @@ describe( 'createOverflowController', () => {
 			expect( header.classList.contains( 'tabber__header--prev-visible' ) ).toBe( false );
 		} );
 
+		it( 'never shows arrows when disabled, even with overflow metrics (wrap mode)', () => {
+			// A single over-wide tab makes scrollWidth > offsetWidth even in wrap
+			// mode; the disabled controller must not surface the arrows/masks.
+			header.classList.add( 'tabber__header--next-visible' );
+			tablist = makeTablist(
+				{ scrollWidth: 500, offsetWidth: 200, clientWidth: 200, scrollLeft: 0 }
+			);
+			const ctl = createOverflowController( {
+				tablist, header, animationsEnabled: false, raf: ( fn ) => fn(), enabled: false
+			} );
+			ctl.update();
+			expect( header.classList.contains( 'tabber__header--next-visible' ) ).toBe( false );
+			expect( header.classList.contains( 'tabber__header--prev-visible' ) ).toBe( false );
+			expect( ctl.isOverflowing() ).toBe( false );
+		} );
+
 		it( 'shows prev-visible when scrolled away from start', () => {
 			tablist = makeTablist(
 				{ scrollWidth: 500, offsetWidth: 200, clientWidth: 200, scrollLeft: 100 }

--- a/tests/vitest/ext.tabberNeue/createTabIndicator.test.js
+++ b/tests/vitest/ext.tabberNeue/createTabIndicator.test.js
@@ -46,4 +46,12 @@ describe( 'createTabIndicator', () => {
 		ind.destroy();
 		expect( tablist.querySelector( ':scope > .tabber__indicator' ) ).toBeNull();
 	} );
+
+	it( 'appends nothing and no-ops when disabled', () => {
+		const ind = createTabIndicator( { tablist, document, enabled: false } );
+		const tab = document.createElement( 'a' );
+		expect( tablist.querySelector( '.tabber__indicator' ) ).toBeNull();
+		expect( () => ind.update( tab ) ).not.toThrow();
+		expect( () => ind.destroy() ).not.toThrow();
+	} );
 } );

--- a/tests/vitest/ext.tabberNeue/createTabber.test.js
+++ b/tests/vitest/ext.tabberNeue/createTabber.test.js
@@ -19,6 +19,12 @@ function makeTabberElement() {
 	return el;
 }
 
+function makeWrapTabberElement() {
+	const el = makeTabberElement();
+	el.classList.add( 'tabber--wrap' );
+	return el;
+}
+
 describe( 'createTabber', () => {
 	let element;
 	let registry;
@@ -69,6 +75,20 @@ describe( 'createTabber', () => {
 			expect( tab.getAttribute( 'tabindex' ) ).toBe( '-1' );
 			expect( tab.getAttribute( 'aria-selected' ) ).toBe( 'false' );
 		}
+	} );
+
+	it( 'creates the floating indicator in normal mode', () => {
+		make();
+		expect( element.querySelector( '.tabber__indicator' ) ).not.toBeNull();
+	} );
+
+	it( 'does not create the floating indicator in wrap mode', () => {
+		document.body.innerHTML = '';
+		element = makeWrapTabberElement();
+		const t = make();
+		const tabs = element.querySelectorAll( '.tabber__tab' );
+		t.init( tabs[ 0 ] );
+		expect( element.querySelector( '.tabber__indicator' ) ).toBeNull();
 	} );
 
 	it( 'init flips --init to --live and activates the given tab', () => {


### PR DESCRIPTION
## Summary

Adds an opt-in **wrap mode** so `<tabber>` / `<tabbertransclude>` tab strips flow onto multiple rows instead of living in a horizontally-scrollable overflow container — a frequently requested alternative to the default scroll-with-arrows behaviour.

- **Trigger:** wiki-wide config `$wgTabberNeueEnableTabWrap` (default `false`), overridable per tag with a `wrap` attribute — `<tabber wrap=true>` enables, `<tabber wrap=false>` disables (a bare `<tabber wrap>` also enables). Resolved server-side into a `tabber--wrap` class on the root `.tabber`. Covers both tags via the shared `TabberRenderer`.
- **CSS** (critical, no layout shift): `.tabber--wrap .tabber__tabs { flex-wrap: wrap; overflow: visible; }`. Individual tabs keep `white-space: nowrap`.
- **Active indicator:** the floating sliding indicator can't span rows, so it's suppressed in wrap mode and the existing per-tab `box-shadow` underline takes over — correct on every row.
- **Overflow arrows/masks:** the overflow controller is disabled in wrap mode. (A tab whose label is wider than the container still produces horizontal overflow even when wrapping, which would otherwise surface a non-functional next-arrow + edge mask; disabling the controller prevents that.)

No i18n changes (attribute/config, not a user-facing message); no new ResourceLoader files. Per-tabber override works in **both** directions — opt a single tabber in when the wiki default is off, or out (`wrap=false`) when it is on; the class-only approach can't remove a server-stamped class, which is why the attribute exists.

## Implementation notes

- `wrap` is stripped from the tag args **before** `Sanitizer::validateTagAttributes`, so the user-controlled value can never leak into the rendered markup; the `tabber--wrap` class is a hardcoded literal. The only user influence is the boolean decision to add it.
- `ParserTestGlobalsHandler` now also resets `TabberNeue.TabberRenderer` between parser tests, since the renderer reads the new config at construction (caught by the config-default parser test).

## Test plan

- [x] PHP PHPUnit (unit + integration): `composer phpunit` → 70/70
- [x] Parser tests (`tests/parser/tabberneue.txt`): `wrap` attribute opt-in, config-default opt-in, and `wrap=false` override → all green. (A `<tabbertransclude wrap>` parser test was dropped: it relied on the Codex `cdx-message` error-box markup, whose CSS class order varies by Codex version across MW branches and breaks exact-match parser tests — the pre-existing transclude parser test uses empty input for the same reason. The transclude wrap path is covered by the shared `TabberRenderer`, the `TabberComponentTabs` unit test, and `TabberTranscludeHandler` forwarding `$args` to the renderer verbatim.)
- [x] Vitest: indicator suppression, overflow-disabled-in-wrap, regression guards → green
- [x] `lint:js`, `lint:styles`, `phpcs` clean
- [x] Browser smoke test (dev wiki): tabs wrap across rows, no horizontal scroll, no arrows/masks (incl. the over-wide-tab case), per-tab underline tracks to the active row, non-wrap tabbers unregressed, console clean of TabberNeue messages
- [x] Reviewer eyeball on a real wiki

> Note: Phan was not run locally — the dev Docker image has php-ast 1.1.2 (< 1.1.3 required by Phan 6.x), a pre-existing environment issue unrelated to this change. CI runs Phan (`analyze-php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)