### PR TITLE
fix: keep VisualEditor Tabber tabs with empty content

### DIFF
--- a/modules/ve-tabberNeue/ve.ui.MWTabberDialog.js
+++ b/modules/ve-tabberNeue/ve.ui.MWTabberDialog.js
@@ -134,7 +134,10 @@ ve.ui.MWTabberDialog.prototype.convertTabsToWikitext = function () {
 		const label = tabPanel.labelInput.getValue().trim();
 		const content = tabPanel.contentInput.getValue().trim();
 
-		if ( label && content ) {
+		// Keep every labelled tab; content is optional (an empty panel is
+		// valid and supported by the parser). Requiring content here silently
+		// dropped tabs whose label was filled but content left blank (#315).
+		if ( label ) {
 			wikitextParts.push( '|-|' + label + ' =\n' + content );
 		}
 	} );

--- a/tests/phpunit/Unit/Parsing/TabSegmentSplitterTest.php
+++ b/tests/phpunit/Unit/Parsing/TabSegmentSplitterTest.php
@@ -41,6 +41,33 @@ class TabSegmentSplitterTest extends MediaWikiUnitTestCase {
 	}
 
 	/**
+	 * A segment that has a label but no content (e.g. "|-|Label=") must be
+	 * kept with an empty rawContent — empty panels are valid. The VisualEditor
+	 * dialog relies on this contract (#315).
+	 *
+	 * @covers ::splitTabber
+	 */
+	public function testSplitTabberSegmentWithEmptyContentIsKept(): void {
+		$result = $this->splitter->splitTabber( '|-|Label=' );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'Label', $result[0]->rawLabel );
+		$this->assertSame( '', $result[0]->rawContent );
+	}
+
+	/**
+	 * An empty-content segment must survive even when sandwiched between
+	 * content-bearing segments (#315).
+	 *
+	 * @covers ::splitTabber
+	 */
+	public function testSplitTabberKeepsEmptyContentSegmentAmongOthers(): void {
+		$result = $this->splitter->splitTabber( '|-|A=1|-|B=|-|C=3' );
+		$this->assertCount( 3, $result );
+		$this->assertSame( [ 'A', 'B', 'C' ], array_map( static fn ( $s ) => $s->rawLabel, $result ) );
+		$this->assertSame( [ '1', '', '3' ], array_map( static fn ( $s ) => $s->rawContent, $result ) );
+	}
+
+	/**
 	 * @covers ::splitTabber
 	 */
 	public function testSplitTabberMultipleSegments(): void {

--- a/tests/phpunit/Unit/Service/TabModelBuilderTest.php
+++ b/tests/phpunit/Unit/Service/TabModelBuilderTest.php
@@ -71,4 +71,33 @@ class TabModelBuilderTest extends MediaWikiUnitTestCase {
 		$this->assertSame( '<p>Body</p>', $tabModel->content );
 		$this->assertSame( $expectedId, $tabModel->id );
 	}
+
+	/**
+	 * A tab with a label but empty content must still build a TabModel (an
+	 * empty panel is valid). Only an empty label skips the tab. The
+	 * VisualEditor dialog relies on this contract (#315).
+	 *
+	 * @covers ::build
+	 */
+	public function testEmptyContentBuildsTabModel(): void {
+		$tabParser = $this->createMock( TabParser::class );
+		$tabParser->method( 'parseLabel' )->willReturn( 'Hello' );
+		$tabParser->method( 'parseContent' )->willReturn( '' );
+
+		$expectedId = TabId::build( 'Hello', true );
+		$tabIdRegistry = $this->createMock( TabIdRegistry::class );
+		$tabIdRegistry->method( 'generateUniqueId' )->willReturn( $expectedId );
+
+		$parserOutput = $this->createMock( ParserOutput::class );
+		$parser = $this->createMock( Parser::class );
+		$parser->method( 'getOutput' )->willReturn( $parserOutput );
+
+		$builder = new TabModelBuilder( $tabParser, $tabIdRegistry );
+		$tabModel = $builder->build( 'Hello', '', $parser );
+
+		$this->assertNotNull( $tabModel, 'A labelled tab with empty content must still build a tab' );
+		$this->assertSame( 'Hello', $tabModel->label );
+		$this->assertSame( '', $tabModel->content );
+		$this->assertSame( $expectedId, $tabModel->id );
+	}
 }

--- a/tests/phpunit/Unit/Service/TabModelBuilderTest.php
+++ b/tests/phpunit/Unit/Service/TabModelBuilderTest.php
@@ -19,85 +19,75 @@ use MediaWikiUnitTestCase;
 class TabModelBuilderTest extends MediaWikiUnitTestCase {
 
 	/**
-	 * @covers ::build
+	 * @param string $parsedLabel Value TabParser::parseLabel should return
+	 * @param string $parsedContent Value TabParser::parseContent should return
+	 * @return TabParser
 	 */
-	public function testEmptyParsedLabelReturnsNull(): void {
+	private function newTabParser( string $parsedLabel, string $parsedContent = '' ): TabParser {
 		$tabParser = $this->createMock( TabParser::class );
-		$tabParser->method( 'parseLabel' )->willReturn( '' );
+		$tabParser->method( 'parseLabel' )->willReturn( $parsedLabel );
+		$tabParser->method( 'parseContent' )->willReturn( $parsedContent );
+		return $tabParser;
+	}
+
+	/**
+	 * @return Parser
+	 */
+	private function newParser(): Parser {
+		$parser = $this->createMock( Parser::class );
+		$parser->method( 'getOutput' )->willReturn( $this->createMock( ParserOutput::class ) );
+		return $parser;
+	}
+
+	/**
+	 * A tab whose label parses to empty is skipped (build returns null) and no
+	 * ID is allocated for it.
+	 *
+	 * @covers ::build
+	 * @dataProvider provideEmptyLabels
+	 */
+	public function testReturnsNullWhenLabelEmpty( string $rawLabel ): void {
 		$tabIdRegistry = $this->createMock( TabIdRegistry::class );
 		$tabIdRegistry->expects( $this->never() )->method( 'generateUniqueId' );
 
-		$builder = new TabModelBuilder( $tabParser, $tabIdRegistry );
-		$parser = $this->createMock( Parser::class );
+		$builder = new TabModelBuilder( $this->newTabParser( '' ), $tabIdRegistry );
 
-		$this->assertNull( $builder->build( '', 'content', $parser ) );
+		$this->assertNull( $builder->build( $rawLabel, 'content', $this->newParser() ) );
+	}
+
+	public static function provideEmptyLabels(): array {
+		return [
+			'empty string' => [ '' ],
+			'whitespace only' => [ '   ' ],
+		];
 	}
 
 	/**
+	 * A labelled tab builds a model carrying the parsed content. Content is
+	 * optional: an empty panel is valid and only an empty label skips the tab
+	 * (#315).
+	 *
 	 * @covers ::build
+	 * @dataProvider provideTabContents
 	 */
-	public function testWhitespaceOnlyLabelReturnsNull(): void {
-		$tabParser = $this->createMock( TabParser::class );
-		$tabParser->method( 'parseLabel' )->willReturn( '' );
-		$tabIdRegistry = $this->createMock( TabIdRegistry::class );
-
-		$builder = new TabModelBuilder( $tabParser, $tabIdRegistry );
-		$parser = $this->createMock( Parser::class );
-
-		$this->assertNull( $builder->build( '   ', 'content', $parser ) );
-	}
-
-	/**
-	 * @covers ::build
-	 */
-	public function testHappyPathBuildsTabModel(): void {
-		$tabParser = $this->createMock( TabParser::class );
-		$tabParser->method( 'parseLabel' )->willReturn( 'Hello' );
-		$tabParser->method( 'parseContent' )->willReturn( '<p>Body</p>' );
-
+	public function testBuildsModelForLabelledTab( string $parsedContent ): void {
 		$expectedId = TabId::build( 'Hello', true );
 		$tabIdRegistry = $this->createMock( TabIdRegistry::class );
 		$tabIdRegistry->method( 'generateUniqueId' )->willReturn( $expectedId );
 
-		$parserOutput = $this->createMock( ParserOutput::class );
-		$parser = $this->createMock( Parser::class );
-		$parser->method( 'getOutput' )->willReturn( $parserOutput );
-
-		$builder = new TabModelBuilder( $tabParser, $tabIdRegistry );
-		$tabModel = $builder->build( 'Hello', 'Body wikitext', $parser );
+		$builder = new TabModelBuilder( $this->newTabParser( 'Hello', $parsedContent ), $tabIdRegistry );
+		$tabModel = $builder->build( 'Hello', 'raw content', $this->newParser() );
 
 		$this->assertNotNull( $tabModel );
 		$this->assertSame( 'Hello', $tabModel->label );
-		$this->assertSame( '<p>Body</p>', $tabModel->content );
+		$this->assertSame( $parsedContent, $tabModel->content );
 		$this->assertSame( $expectedId, $tabModel->id );
 	}
 
-	/**
-	 * A tab with a label but empty content must still build a TabModel (an
-	 * empty panel is valid). Only an empty label skips the tab. The
-	 * VisualEditor dialog relies on this contract (#315).
-	 *
-	 * @covers ::build
-	 */
-	public function testEmptyContentBuildsTabModel(): void {
-		$tabParser = $this->createMock( TabParser::class );
-		$tabParser->method( 'parseLabel' )->willReturn( 'Hello' );
-		$tabParser->method( 'parseContent' )->willReturn( '' );
-
-		$expectedId = TabId::build( 'Hello', true );
-		$tabIdRegistry = $this->createMock( TabIdRegistry::class );
-		$tabIdRegistry->method( 'generateUniqueId' )->willReturn( $expectedId );
-
-		$parserOutput = $this->createMock( ParserOutput::class );
-		$parser = $this->createMock( Parser::class );
-		$parser->method( 'getOutput' )->willReturn( $parserOutput );
-
-		$builder = new TabModelBuilder( $tabParser, $tabIdRegistry );
-		$tabModel = $builder->build( 'Hello', '', $parser );
-
-		$this->assertNotNull( $tabModel, 'A labelled tab with empty content must still build a tab' );
-		$this->assertSame( 'Hello', $tabModel->label );
-		$this->assertSame( '', $tabModel->content );
-		$this->assertSame( $expectedId, $tabModel->id );
+	public static function provideTabContents(): array {
+		return [
+			'non-empty content' => [ '<p>Body</p>' ],
+			'empty content (#315)' => [ '' ],
+		];
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #315.

In VisualEditor's Tabber dialog, a tab with a filled **Tab label** but blank **Tab content** was silently dropped from the page on "Apply changes".

### Root cause

`ve.ui.MWTabberDialog.convertTabsToWikitext` gated each tab on `if ( label && content )`, so a labelled tab with empty content produced no `|-|Label =` segment. But the dialog validates only the **label** (content is optional), so such a tab passed validation and was then discarded at serialization — silent data loss.

Empty-content tabs are a supported feature elsewhere in the stack: `TabSegmentSplitter::splitTabber` keeps any `=`-bearing segment, and `TabModelBuilder::build` skips a tab only when its **label** is empty. The fix gates on the label alone, so the VE dialog matches that behaviour.

### Changes

- `ve.ui.MWTabberDialog.js`: `if ( label && content )` → `if ( label )` (with an explanatory comment).
- PHPUnit regression tests locking in the empty-content contract the fix relies on (`TabSegmentSplitterTest`, `TabModelBuilderTest`).

The TabberTransclude dialog is intentionally unchanged — it requires both label and page, and validates both.

## Testing

- `npm run lint:js` / `lint:styles` / `lint:i18n`, and `npm test` (117/117) — all pass.
- `composer test` (parallel-lint, phpcs, minus-x) — pass.
- New PHPUnit unit tests pass: `TabSegmentSplitter` keeps a `|-|Label=` segment with empty content; `TabModelBuilder` builds a non-null model for a labelled tab with empty content.
- Manual browser test (MediaWiki + VisualEditor): created Tab "Alpha" (label + content) and Tab "Beta" (label, empty content) → Apply inserts **both** tabs (`|-|Alpha = … |-|Beta =`); Beta renders as an empty panel; re-opening the dialog round-trips Beta with its label and empty content. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)