### PR TITLE
fix: W3C-valid tab markup — <div> panels + aria-hidden indicator (#309)

### DIFF
--- a/includes/templates/Tabs.mustache
+++ b/includes/templates/Tabs.mustache
@@ -9,9 +9,9 @@
 		}}<button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button>{{!
 	}}</header>{{!
 
-	}}<section class="tabber__section">{{!
+	}}<div class="tabber__section">{{!
 		}}{{#array-tabs}}{{!
-			}}<article class="tabber__panel" role="tabpanel" tabindex="0" {{#array-tabpanel-attributes}} {{key}}="{{{value}}}"{{/array-tabpanel-attributes}}>{{{content}}}</article>{{!
+			}}<div class="tabber__panel" role="tabpanel" tabindex="0" {{#array-tabpanel-attributes}} {{key}}="{{{value}}}"{{/array-tabpanel-attributes}}>{{{content}}}</div>{{!
 		}}{{/array-tabs}}{{!
-	}}</section>{{!
+	}}</div>{{!
 }}</div>

--- a/modules/ext.tabberNeue/createTabIndicator.js
+++ b/modules/ext.tabberNeue/createTabIndicator.js
@@ -31,6 +31,10 @@ function createTabIndicator( opts ) {
 
 	const element = doc.createElement( 'span' );
 	element.className = 'tabber__indicator';
+	// Decorative sliding underline. aria-hidden keeps it out of the a11y tree
+	// so role="tablist" exposes only its tab children; it must stay a tablist
+	// child for the stylesheet's :has( > .tabber__indicator ) selector.
+	element.setAttribute( 'aria-hidden', 'true' );
 	tablist.appendChild( element );
 
 	/**

--- a/modules/ext.tabberNeue/ext.tabberNeue.less
+++ b/modules/ext.tabberNeue/ext.tabberNeue.less
@@ -2,7 +2,7 @@
 	&__header {
 		position: relative;
 		display: flex;
-		/* defend against <section> needing 100% */
+		/* defend against .tabber__section needing 100% */
 		flex-shrink: 0;
 		flex-direction: column;
 		/* fixes cross browser quarks */

--- a/modules/ext.tabberNeue/loadTransclusion.js
+++ b/modules/ext.tabberNeue/loadTransclusion.js
@@ -67,6 +67,12 @@ async function loadTransclusion( opts ) {
 			throw new Error( 'Invalid data structure received from server.' );
 		}
 
+		// Known limitation: the transcluded page's parsed HTML is generated
+		// from a separate ParserOutput, so its element IDs (section anchors,
+		// its own tabber IDs, etc.) can collide with IDs already on the host
+		// page, producing duplicate IDs in the live DOM. This is runtime-only
+		// (invisible to static W3C validation); we intentionally do not rewrite
+		// the injected IDs, which would break that content's own anchors/TOC.
 		panel.innerHTML = data.parse.text;
 		if ( onContentReplaced ) {
 			onContentReplaced( panel );

--- a/tests/parser/tabberneue.txt
+++ b/tests/parser/tabberneue.txt
@@ -28,16 +28,16 @@ Second content.
 Third content.
 </tabber>
 !! html
-<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a><a class="tabber__tab" role="tab" id="tabber-Third-label" href="#tabber-Third" aria-controls="tabber-Third">Third</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a><a class="tabber__tab" role="tab" id="tabber-Third-label" href="#tabber-Third" aria-controls="tabber-Third">Third</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
 </p><p>First content.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
 </p><p>Second content.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Third" aria-labelledby="tabber-Third-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Third" aria-labelledby="tabber-Third-label"><p class="mw-empty-elt">
 </p><p>Third content.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -60,10 +60,10 @@ wgTabberNeueAddTabPrefix=true
 A [[Main Page|link]] here.
 </tabber>
 !! html
-<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-List-label" href="#tabber-List" aria-controls="tabber-List">List</a><a class="tabber__tab" role="tab" id="tabber-Table-label" href="#tabber-Table" aria-controls="tabber-Table">Table</a><a class="tabber__tab" role="tab" id="tabber-Link-label" href="#tabber-Link" aria-controls="tabber-Link">Link</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-List" aria-labelledby="tabber-List-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-List-label" href="#tabber-List" aria-controls="tabber-List">List</a><a class="tabber__tab" role="tab" id="tabber-Table-label" href="#tabber-Table" aria-controls="tabber-Table">Table</a><a class="tabber__tab" role="tab" id="tabber-Link-label" href="#tabber-Link" aria-controls="tabber-Link">Link</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-List" aria-labelledby="tabber-List-label"><p class="mw-empty-elt">
 </p><ul><li>one</li>
 <li>two</li></ul>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Table" aria-labelledby="tabber-Table-label">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Table" aria-labelledby="tabber-Table-label">
 <table class="wikitable">
 <tbody><tr>
 <th>H1</th>
@@ -73,9 +73,10 @@ A [[Main Page|link]] here.
 <td>a</td>
 <td>b
 </td></tr></tbody></table>
-</article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Link" aria-labelledby="tabber-Link-label"><p>
-A <a href="/index.php?title=Main_Page&amp;action=edit&amp;redlink=1" class="new" title="Main Page (page does not exist)">link</a> here.
-</p></article></section></div>
+</div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Link" aria-labelledby="tabber-Link-label"><p class="mw-empty-elt">
+</p><p>A <a href="/index.php?title=Main_Page&amp;action=edit&amp;redlink=1" class="new" title="Main Page (page does not exist)">link</a> here.
+</p>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -91,13 +92,13 @@ content A
 content B
 </tabber>
 !! html
-<div class="tabber tabber--init custom-class" id="custom-id" data-test="custom"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-A-label" href="#tabber-A" aria-controls="tabber-A">A</a><a class="tabber__tab" role="tab" id="tabber-B-label" href="#tabber-B" aria-controls="tabber-B">B</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-A" aria-labelledby="tabber-A-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init custom-class" id="custom-id" data-test="custom"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-A-label" href="#tabber-A" aria-controls="tabber-A">A</a><a class="tabber__tab" role="tab" id="tabber-B-label" href="#tabber-B" aria-controls="tabber-B">B</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-A" aria-labelledby="tabber-A-label"><p class="mw-empty-elt">
 </p><p>content A
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-B" aria-labelledby="tabber-B-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-B" aria-labelledby="tabber-B-label"><p class="mw-empty-elt">
 </p><p>content B
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -119,18 +120,18 @@ Inner 2 content.
 Outer B plain.
 </tabber>
 !! html
-<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Outer_A-label" href="#tabber-Outer_A" aria-controls="tabber-Outer_A">Outer A</a><a class="tabber__tab" role="tab" id="tabber-Outer_B-label" href="#tabber-Outer_B" aria-controls="tabber-Outer_B">Outer B</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Outer_A" aria-labelledby="tabber-Outer_A-label"><p class="mw-empty-elt">
-</p><div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Inner_1-label" href="#tabber-Inner_1" aria-controls="tabber-Inner_1">Inner 1</a><a class="tabber__tab" role="tab" id="tabber-Inner_2-label" href="#tabber-Inner_2" aria-controls="tabber-Inner_2">Inner 2</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Inner_1" aria-labelledby="tabber-Inner_1-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Outer_A-label" href="#tabber-Outer_A" aria-controls="tabber-Outer_A">Outer A</a><a class="tabber__tab" role="tab" id="tabber-Outer_B-label" href="#tabber-Outer_B" aria-controls="tabber-Outer_B">Outer B</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Outer_A" aria-labelledby="tabber-Outer_A-label"><p class="mw-empty-elt">
+</p><div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Inner_1-label" href="#tabber-Inner_1" aria-controls="tabber-Inner_1">Inner 1</a><a class="tabber__tab" role="tab" id="tabber-Inner_2-label" href="#tabber-Inner_2" aria-controls="tabber-Inner_2">Inner 2</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Inner_1" aria-labelledby="tabber-Inner_1-label"><p class="mw-empty-elt">
 </p><p>Inner 1 content.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Inner_2" aria-labelledby="tabber-Inner_2-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Inner_2" aria-labelledby="tabber-Inner_2-label"><p class="mw-empty-elt">
 </p><p>Inner 2 content.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Outer_B" aria-labelledby="tabber-Outer_B-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div></div></div>
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Outer_B" aria-labelledby="tabber-Outer_B-label"><p class="mw-empty-elt">
 </p><p>Outer B plain.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -148,16 +149,16 @@ Second.
 Third.
 </tabber>
 !! html
-<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Same-label" href="#tabber-Same" aria-controls="tabber-Same">Same</a><a class="tabber__tab" role="tab" id="tabber-Same_2-label" href="#tabber-Same_2" aria-controls="tabber-Same_2">Same</a><a class="tabber__tab" role="tab" id="tabber-Same_3-label" href="#tabber-Same_3" aria-controls="tabber-Same_3">Same</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Same" aria-labelledby="tabber-Same-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Same-label" href="#tabber-Same" aria-controls="tabber-Same">Same</a><a class="tabber__tab" role="tab" id="tabber-Same_2-label" href="#tabber-Same_2" aria-controls="tabber-Same_2">Same</a><a class="tabber__tab" role="tab" id="tabber-Same_3-label" href="#tabber-Same_3" aria-controls="tabber-Same_3">Same</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Same" aria-labelledby="tabber-Same-label"><p class="mw-empty-elt">
 </p><p>First.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Same_2" aria-labelledby="tabber-Same_2-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Same_2" aria-labelledby="tabber-Same_2-label"><p class="mw-empty-elt">
 </p><p>Second.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Same_3" aria-labelledby="tabber-Same_3-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Same_3" aria-labelledby="tabber-Same_3-label"><p class="mw-empty-elt">
 </p><p>Third.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -173,13 +174,13 @@ Body of the bold-labeled tab.
 Body of the italic-labeled tab.
 </tabber>
 !! html
-<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Bold_label-label" href="#tabber-Bold_label" aria-controls="tabber-Bold_label"><b>Bold label</b></a><a class="tabber__tab" role="tab" id="tabber-Italic_label-label" href="#tabber-Italic_label" aria-controls="tabber-Italic_label"><i>Italic label</i></a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Bold_label" aria-labelledby="tabber-Bold_label-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Bold_label-label" href="#tabber-Bold_label" aria-controls="tabber-Bold_label"><b>Bold label</b></a><a class="tabber__tab" role="tab" id="tabber-Italic_label-label" href="#tabber-Italic_label" aria-controls="tabber-Italic_label"><i>Italic label</i></a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Bold_label" aria-labelledby="tabber-Bold_label-label"><p class="mw-empty-elt">
 </p><p>Body of the bold-labeled tab.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Italic_label" aria-labelledby="tabber-Italic_label-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Italic_label" aria-labelledby="tabber-Italic_label-label"><p class="mw-empty-elt">
 </p><p>Body of the italic-labeled tab.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -195,13 +196,13 @@ Content.
 Content.
 </tabber>
 !! html
-<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Bold-label" href="#tabber-Bold" aria-controls="tabber-Bold"><b>Bold</b></a><a class="tabber__tab" role="tab" id="tabber-Italic-label" href="#tabber-Italic" aria-controls="tabber-Italic"><i>Italic</i></a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Bold" aria-labelledby="tabber-Bold-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-Bold-label" href="#tabber-Bold" aria-controls="tabber-Bold"><b>Bold</b></a><a class="tabber__tab" role="tab" id="tabber-Italic-label" href="#tabber-Italic" aria-controls="tabber-Italic"><i>Italic</i></a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Bold" aria-labelledby="tabber-Bold-label"><p class="mw-empty-elt">
 </p><p>Content.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Italic" aria-labelledby="tabber-Italic-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Italic" aria-labelledby="tabber-Italic-label"><p class="mw-empty-elt">
 </p><p>Content.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -217,13 +218,13 @@ Content.
 Content.
 </tabber>
 !! html
-<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B-label" href="#tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B" aria-controls="tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B">&#39;&#39;&#39;Bold&#39;&#39;&#39;</a><a class="tabber__tab" role="tab" id="tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B-label" href="#tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B" aria-controls="tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B">&#39;&#39;Italic&#39;&#39;</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B" aria-labelledby="tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B-label" href="#tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B" aria-controls="tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B">&#39;&#39;&#39;Bold&#39;&#39;&#39;</a><a class="tabber__tab" role="tab" id="tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B-label" href="#tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B" aria-controls="tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B">&#39;&#39;Italic&#39;&#39;</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B" aria-labelledby="tabber-.26.23039.3B.26.23039.3B.26.23039.3BBold.26.23039.3B.26.23039.3B.26.23039.3B-label"><p class="mw-empty-elt">
 </p><p>Content.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B" aria-labelledby="tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B" aria-labelledby="tabber-.26.23039.3B.26.23039.3BItalic.26.23039.3B.26.23039.3B-label"><p class="mw-empty-elt">
 </p><p>Content.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -239,13 +240,13 @@ A.
 B.
 </tabber>
 !! html
-<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="Alpha-label" href="#Alpha" aria-controls="Alpha">Alpha</a><a class="tabber__tab" role="tab" id="Beta-label" href="#Beta" aria-controls="Beta">Beta</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="Alpha" aria-labelledby="Alpha-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="Alpha-label" href="#Alpha" aria-controls="Alpha">Alpha</a><a class="tabber__tab" role="tab" id="Beta-label" href="#Beta" aria-controls="Beta">Beta</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="Alpha" aria-labelledby="Alpha-label"><p class="mw-empty-elt">
 </p><p>A.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="Beta" aria-labelledby="Beta-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="Beta" aria-labelledby="Beta-label"><p class="mw-empty-elt">
 </p><p>B.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -273,13 +274,13 @@ First content.
 Second content.
 </tabber>
 !! html
-<div class="tabber tabber--init tabber--wrap"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init tabber--wrap"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
 </p><p>First content.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
 </p><p>Second content.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -296,13 +297,13 @@ First content.
 Second content.
 </tabber>
 !! html
-<div class="tabber tabber--init tabber--wrap"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init tabber--wrap"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
 </p><p>First content.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
 </p><p>Second content.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end
 
 !! test
@@ -319,11 +320,11 @@ First content.
 Second content.
 </tabber>
 !! html
-<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><section class="tabber__section"><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
+<div class="tabber tabber--init"><header class="tabber__header"><button class="tabber__header__prev" tabindex="-1" type="button" aria-hidden="true"></button><nav class="tabber__tabs" role="tablist"><a class="tabber__tab" role="tab" id="tabber-First-label" href="#tabber-First" aria-controls="tabber-First">First</a><a class="tabber__tab" role="tab" id="tabber-Second-label" href="#tabber-Second" aria-controls="tabber-Second">Second</a></nav><button class="tabber__header__next" tabindex="-1" type="button" aria-hidden="true"></button></header><div class="tabber__section"><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-First" aria-labelledby="tabber-First-label"><p class="mw-empty-elt">
 </p><p>First content.
 </p>
-<p class="mw-empty-elt"></p></article><article class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
+<p class="mw-empty-elt"></p></div><div class="tabber__panel" role="tabpanel" tabindex="0" id="tabber-Second" aria-labelledby="tabber-Second-label"><p class="mw-empty-elt">
 </p><p>Second content.
 </p>
-<p class="mw-empty-elt"></p></article></section></div>
+<p class="mw-empty-elt"></p></div></div></div>
 !! end

--- a/tests/vitest/ext.tabberNeue/createPanelTransition.test.js
+++ b/tests/vitest/ext.tabberNeue/createPanelTransition.test.js
@@ -6,8 +6,8 @@ describe( 'createPanelTransition', () => {
 	let newPanel;
 
 	beforeEach( () => {
-		prevPanel = document.createElement( 'article' );
-		newPanel = document.createElement( 'article' );
+		prevPanel = document.createElement( 'div' );
+		newPanel = document.createElement( 'div' );
 		Object.defineProperty( prevPanel, 'offsetLeft', { value: 0, configurable: true } );
 		Object.defineProperty( newPanel, 'offsetLeft', { value: 300, configurable: true } );
 		document.body.appendChild( prevPanel );

--- a/tests/vitest/ext.tabberNeue/createTabIndicator.test.js
+++ b/tests/vitest/ext.tabberNeue/createTabIndicator.test.js
@@ -21,6 +21,12 @@ describe( 'createTabIndicator', () => {
 		expect( indicator.tagName ).toBe( 'SPAN' );
 	} );
 
+	it( 'marks the indicator aria-hidden so the tablist exposes only tabs', () => {
+		createTabIndicator( { tablist, document } );
+		const indicator = tablist.querySelector( ':scope > .tabber__indicator' );
+		expect( indicator.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+	} );
+
 	it( 'update sets transform and width from the active tab geometry', () => {
 		const ind = createTabIndicator( { tablist, document } );
 		const tab = document.createElement( 'a' );

--- a/tests/vitest/ext.tabberNeue/createTabber.test.js
+++ b/tests/vitest/ext.tabberNeue/createTabber.test.js
@@ -10,10 +10,10 @@ function makeTabberElement() {
 				<a class="tabber__tab" role="tab" aria-controls="p2">B</a>
 			</nav>
 		</div>
-		<section class="tabber__section">
-			<article class="tabber__panel" id="p1">one</article>
-			<article class="tabber__panel" id="p2">two</article>
-		</section>
+		<div class="tabber__section">
+			<div class="tabber__panel" id="p1">one</div>
+			<div class="tabber__panel" id="p2">two</div>
+		</div>
 	`;
 	document.body.appendChild( el );
 	return el;
@@ -232,10 +232,10 @@ describe( 'createTabber animation orchestration', () => {
 					<a class="tabber__tab" role="tab" aria-controls="p2">B</a>
 				</nav>
 			</div>
-			<section class="tabber__section">
-				<article class="tabber__panel" id="p1">one</article>
-				<article class="tabber__panel" id="p2">two</article>
-			</section>
+			<div class="tabber__section">
+				<div class="tabber__panel" id="p1">one</div>
+				<div class="tabber__panel" id="p2">two</div>
+			</div>
 		`;
 		document.body.appendChild( element );
 

--- a/tests/vitest/ext.tabberNeue/createViewTransitionWrapper.test.js
+++ b/tests/vitest/ext.tabberNeue/createViewTransitionWrapper.test.js
@@ -5,7 +5,7 @@ describe( 'createViewTransitionWrapper', () => {
 	let section;
 
 	beforeEach( () => {
-		section = document.createElement( 'section' );
+		section = document.createElement( 'div' );
 		document.body.appendChild( section );
 		document.documentElement.classList.add( 'tabber-animations-ready' );
 	} );

--- a/tests/vitest/ext.tabberNeue/tabberRegistry.test.js
+++ b/tests/vitest/ext.tabberNeue/tabberRegistry.test.js
@@ -55,9 +55,9 @@ describe( 'tabberRegistry', () => {
 			<div class="tabber__header">
 				<nav class="tabber__tabs"><a class="tabber__tab" aria-controls="${ id }-p1">A</a></nav>
 			</div>
-			<section class="tabber__section">
-				<article class="tabber__panel" id="${ id }-p1">x</article>
-			</section>
+			<div class="tabber__section">
+				<div class="tabber__panel" id="${ id }-p1">x</div>
+			</div>
 		`;
 		document.body.appendChild( el );
 		return el;


### PR DESCRIPTION
## Summary

Makes TabberNeue's own rendered markup pass the [W3C Nu HTML Checker](https://validator.w3.org/nu/) (#309). The validator flagged three TabberNeue-attributable issues on every `<tabber>` page:

1. **Error** — `Bad value "tabpanel" for attribute "role" on element "article"`: `<article>` does not permit `role="tabpanel"`.
2. **Warning** — *Article lacks heading* on each tab panel.
3. **Warning** — *Section lacks heading* on the `<section>` wrapper.

## Changes

- **`Tabs.mustache`** — tab panel `<article class="tabber__panel" role="tabpanel">` → `<div>`, and the `<section class="tabber__section">` wrapper → `<div>`. `<div>` accepts any ARIA role and is never heading-checked — the WAI-ARIA APG canonical tabs markup. `role="tabpanel"` + `aria-labelledby` preserve each panel's accessible name, so accessibility is unchanged. (`<nav role="tablist">` and `<a href role="tab">` were already valid and are kept as-is.)
- **`createTabIndicator.js`** — `aria-hidden="true"` on the decorative sliding-indicator span, so `role="tablist"` exposes only its tabs. The span must stay a tablist child (the stylesheet's `:has( > .tabber__indicator )` selector depends on it), so it's hidden rather than relocated.
- **`loadTransclusion.js`** — comment documenting a known runtime duplicate-ID limitation (intentionally not fixed; runtime-only, invisible to the validator).
- Parser and vitest fixtures updated to match.

## No CSS/JS behaviour change

All stylesheet and script selectors target by class (`.tabber__panel`, `.tabber__section`); there are no element-name selectors, so the rename is invisible to styling/scripting. Verified that the new CSS/JS works against stale, parser-cached `<article>`/`<section>` HTML (and vice-versa), so there is no mismatch during the upgrade/rollout window.

## Note on `mw-empty-elt` paragraphs

The parser-test fixtures for inline tab content now include hidden `<p class="mw-empty-elt">` paragraphs. This is **not** a new behaviour: real page rendering already produced them under `<article>` — the old fixtures simply didn't match real `action=parse` output for non-block elements. `<div>` makes the fixtures match reality. They are `display:none` and valid HTML. Removing them would require either `recursiveTagParseFully` (benchmarked **2.6–4.85× slower** per tab) or a `ParserAfterTidy` pass, so it's out of scope here.

## Test plan

- [x] Parser tests: `php tests/phpunit/phpunit.php --group ParserTests --filter 'TabberNeue'` → **13/13**
- [x] JS: `npm test` → **118/118**; `npm run lint:js` and `npm run lint:styles` clean
- [x] Live W3C check on a dev wiki — rendered `<tabber>` now emits `<div role="tabpanel">` / `<div class="tabber__section">`, **0** `<article>`/`<section>`, ARIA roles intact (tablist/tab/tabpanel); all three findings gone
- [x] In-browser: tab switching, sliding indicator, keyboard nav all work; console clean

## Follow-ups (separate issues)

- Tab-label content sanitization — wikilink/file/list labels under `wgTabberNeueParseTabName=true` produce broken/empty tabs (illegal nested `<a>` / block-in-`<a>`).
- Conditional panel `tabindex` per APG (only when the panel has no focusable descendant).
- Duplicate-`id` collision when a tab is named `…-label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tab panels to render with simpler container elements while keeping the same tab behavior and accessibility roles.
  * The tab indicator is now hidden from screen readers, reducing unnecessary accessibility noise.
  * Improved handling notes around transcluded content and ID collisions.

* **Tests**
  * Updated tabber-related tests to match the revised markup and accessibility expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->