### PR TITLE
fix: stop tab content breaking out of the container during transitions

### DIFF
--- a/modules/ext.tabberNeue/createTabber.js
+++ b/modules/ext.tabberNeue/createTabber.js
@@ -104,8 +104,17 @@ function createTabber( opts ) {
 				onContentReplaced: ( p ) => mwApi.hook( 'wikipage.content' ).fire( $( p ) )
 			} );
 		}
-		const h = getElementSize( panel, 'height' );
-		section.style.height = h + 'px';
+		// In the View Transitions path the destination height is pre-applied
+		// before the transition starts (see activate) so the old and new
+		// captures share one section height. Re-applying it here would run
+		// inside the update callback and reflow the page between the two
+		// captures — the root snapshot then cross-fades the whole page below,
+		// and the taller panel's snapshot (unclipped by the section overflow)
+		// spills out of the container.
+		if ( !options.preventHeight ) {
+			const h = getElementSize( panel, 'height' );
+			section.style.height = h + 'px';
+		}
 		if ( !options.preventScroll ) {
 			// Synchronous: any IO entry from this write lands inside pauseDuring's
 			// 150ms quiet window. Deferring via rAF breaks the View Transitions
@@ -163,7 +172,17 @@ function createTabber( opts ) {
 			const direction = newPanel.offsetLeft > previousActivePanel.offsetLeft ?
 				'forward' :
 				'backward';
-			units.vt.wrap( () => performActivation( tab, options ), direction );
+			// Apply the destination height before starting the transition so
+			// both view-transition captures share one section height. Changing
+			// it inside the update callback instead reflows the page between the
+			// old and new snapshots, causing the whole page below to cross-fade
+			// (root snapshot) and the taller panel to spill out of the
+			// overflow-clipped container.
+			section.style.height = getElementSize( newPanel, 'height' ) + 'px';
+			units.vt.wrap(
+				() => performActivation( tab, Object.assign( {}, options, { preventHeight: true } ) ),
+				direction
+			);
 			return;
 		}
 

--- a/tests/vitest/ext.tabberNeue/createTabber.test.js
+++ b/tests/vitest/ext.tabberNeue/createTabber.test.js
@@ -316,6 +316,52 @@ describe( 'createTabber animation orchestration', () => {
 		}
 	} );
 
+	it( 'applies the destination height before the view-transition callback so both captures share it', () => {
+		// The browser defers the update callback; capture it without running it,
+		// mirroring the gap between the old-state and new-state snapshots.
+		let capturedCallback = null;
+		const mockVT = vi.fn( ( cb ) => {
+			capturedCallback = cb;
+			return {
+				finished: Promise.resolve(),
+				ready: Promise.resolve(),
+				updateCallbackDone: Promise.resolve()
+			};
+		} );
+		document.startViewTransition = mockVT;
+		try {
+			// Old panel 100px tall, destination panel 250px tall.
+			vi.spyOn( panels[ 0 ], 'getBoundingClientRect' )
+				.mockReturnValue( { width: 100, height: 100 } );
+			vi.spyOn( panels[ 1 ], 'getBoundingClientRect' )
+				.mockReturnValue( { width: 100, height: 250 } );
+			const t = make();
+			t.init( tabs[ 0 ] );
+			const section = element.querySelector( '.tabber__section' );
+			expect( section.style.height ).toBe( '100px' );
+
+			t.activate( tabs[ 1 ], { source: 'user-click' } );
+
+			// The destination height must be applied up front, before the deferred
+			// callback runs, so the old and new captures share one section height.
+			// Otherwise the page reflows between the two snapshots: the root
+			// snapshot cross-fades the whole page below and the taller panel's
+			// snapshot spills out of the (overflow-clipped) container.
+			expect( mockVT ).toHaveBeenCalledTimes( 1 );
+			expect( section.style.height ).toBe( '250px' );
+
+			// Running the callback (what the browser does between captures) must
+			// not re-read or re-apply the height. Re-mock the destination panel
+			// to a different height first, so a regression that measures inside
+			// the callback would be caught here.
+			panels[ 1 ].getBoundingClientRect.mockReturnValue( { width: 100, height: 999 } );
+			capturedCallback();
+			expect( section.style.height ).toBe( '250px' );
+		} finally {
+			delete document.startViewTransition;
+		}
+	} );
+
 	it( 'panel-scroll activation bypasses both VT and the fallback class', () => {
 		const mockVT = vi.fn( () => ( {
 			finished: Promise.resolve(),


### PR DESCRIPTION
## Problem

When switching between tabs whose panels have **different heights**, the animated tab transition made content **break out of the container and slide in**, and the whole page below the tabber briefly **ghosted/doubled**. It reproduces on a single switch (either direction) and on mid-transition interrupts; equal-height tabbers were never affected.

## Root cause

`setActivePanel()` wrote the section's per-panel height (`section.style.height = getElementSize(panel)`) **inside** the `startViewTransition` update callback. The browser captures the *old* state before the callback and the *new* state after it, so the two snapshots were captured at **different section heights**. That single delta caused two defects:

1. **Content spills below the container.** The taller of the two `::view-transition-old/new(tabber-section-*)` snapshots renders at full panel height in the browser **top layer**, which is *not* clipped by `.tabber { overflow: hidden }` — so a tall panel's content overflows down over the following content.
2. **Page below ghosts.** Because only `.tabber__section` carries a `view-transition-name`, the default `root` snapshot captures the entire rest of the page. The height change reflows everything below the tabber, so `root`-old vs `root`-new differ and the lower page cross-fades in two positions at once.

The non-View-Transitions fallback path (`--entering-*`) was immune, because it slides a *real* element inside the section's `overflow: hidden` box and has no `root` snapshot.

## Fix

Apply the destination panel's height **before** `startViewTransition`, and skip the redundant write inside the update callback via a new `preventHeight` option. Both captures then share one section height:

- no page reflow between captures → no `root`-snapshot ghost;
- both section snapshots are clipped to the section box → no overflow.

This mirrors the fallback path's behaviour (instant height, then slide) and deliberately keeps the height change as a **single, one-time** layout — no per-frame height animation. (Smooth height animation was explored and rejected: it would require reflowing the content below the tabber every frame, and the performance cost isn't worth it.)

## Testing

- New regression test in `createTabber.test.js`: fails without the fix (height stays at the old value because it was only set in the deferred callback), passes with it; also guards that the callback does not re-apply the height.
- Full JS suite green (`npm test`), `npm run lint:js` clean.
- **Manual browser verification** (View Transitions, Chrome, dev wiki), frozen mid-transition via `getAnimations()` scrubbing:
  - tall→short and short→tall single switches: content clipped to the box, no ghost, no overflow;
  - mid-transition interrupt (switch during an in-flight transition): clean;
  - equal-height tabbers: unchanged;
  - `view-transition-name` clears after each transition, no leftover animations, no console errors/warnings.

## Review

Reviewed by a fresh-context reviewer: verdict **ready to merge**, no Critical/Important issues. All non-VT paths (init, fallback, `handleResize`, in-panel anchor) still apply the height; `preventHeight` is scoped only to the VT callback.

Opened as **draft** for your review.
