### PR TITLE
fix: enlarge the overflow arrow hit target to 32px

### DIFF
--- a/modules/ext.tabberNeue/ext.tabberNeue.less
+++ b/modules/ext.tabberNeue/ext.tabberNeue.less
@@ -1,5 +1,6 @@
 .tabber {
 	&__header {
+		--tabber-arrow-width: 32px;
 		position: relative;
 		display: flex;
 		/* defend against .tabber__section needing 100% */
@@ -8,6 +9,11 @@
 		/* fixes cross browser quarks */
 		min-block-size: fit-content;
 		box-shadow: inset 0 -1px 0 0 var( --border-color-base, #a2a9b1 );
+
+		@media ( hover: none ) {
+			/* stylelint-disable-next-line length-zero-no-unit */
+			--tabber-arrow-width: 0px;
+		}
 
 		button {
 			/* Remove all default button styles */
@@ -30,7 +36,7 @@
 			bottom: 0;
 			z-index: 1;
 			display: none; // Required as all:unset also unset display:none
-			width: 20px;
+			width: var( --tabber-arrow-width );
 			cursor: pointer;
 			border-radius: 4px;
 
@@ -47,18 +53,18 @@
 		}
 
 		&--prev-visible .tabber__tabs {
-			-webkit-mask-image: linear-gradient( 90deg, transparent, #000 20% );
-			mask-image: linear-gradient( 90deg, transparent, #000 20% );
+			-webkit-mask-image: linear-gradient( 90deg, transparent var( --tabber-arrow-width ), #000 20% );
+			mask-image: linear-gradient( 90deg, transparent var( --tabber-arrow-width ), #000 20% );
 		}
 
 		&--next-visible .tabber__tabs {
-			-webkit-mask-image: linear-gradient( 90deg, #000 80%, transparent );
-			mask-image: linear-gradient( 90deg, #000 80%, transparent );
+			-webkit-mask-image: linear-gradient( 90deg, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
+			mask-image: linear-gradient( 90deg, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
 		}
 
 		&--prev-visible.tabber__header--next-visible .tabber__tabs {
-			-webkit-mask-image: linear-gradient( 90deg, transparent, #000 20%, #000 80%, transparent );
-			mask-image: linear-gradient( 90deg, transparent, #000 20%, #000 80%, transparent );
+			-webkit-mask-image: linear-gradient( 90deg, transparent var( --tabber-arrow-width ), #000 20%, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
+			mask-image: linear-gradient( 90deg, transparent var( --tabber-arrow-width ), #000 20%, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
 		}
 
 		&--prev-visible .tabber__header__prev,
@@ -290,22 +296,6 @@
 	to {
 		opacity: 1;
 		transform: translateX( 0 );
-	}
-}
-
-@media ( hover: none ) {
-	// Need extra specificity to override
-	.tabber {
-		.tabber__header {
-			&__prev,
-			&__next {
-				pointer-events: none; // Disable arrow button
-
-				&::after {
-					background-image: none; // Remove arrow icon
-				}
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
Prompted by #308, which asks for mouse drag-to-scroll on wide tab bars. That request is not implemented here — see the discussion on the issue — but the complaint behind it ("tiny arrow buttons") turned out to be a live accessibility defect, which this fixes.

## Target size

The prev/next arrows were `width: 20px`, below the 24×24 CSS px minimum in [WCAG 2.2 SC 2.5.8](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html) (AA). No exception rescues it — they are `position: absolute; z-index: 1` over `.tabber__tabs`, so a 24px circle centred on a 20×36 box necessarily intersects a tab target. The number has been unchanged since the extension's first commit.

They are now 32px, matching Codex's scroll buttons. Measured 32×42 with the glyph centred on the button centre.

## The strip under the arrow

Previously the mask left the tab under an arrow partially visible — faded, but still reading as clickable, and clicking it scrolled instead of activating the tab. The mask now holds fully transparent across the arrow, so that span reads as chrome.

Codex gets this from an opaque scroller background (`background-color: inherit` over a header committed to `--background-color-base`). That does not port: `.tabber__header` computes to `rgba(0, 0, 0, 0)`, so `inherit` would be a no-op, and giving the header a base background would paint a solid block behind every tabber embedded in a coloured infobox or template. Masking stays correct on any parent background.

## One knob instead of three

`--tabber-arrow-width` drives both the button width and the mask span. Touch devices scroll the strip natively and get no arrows, so `0px` there collapses the button entirely — no width means no hit area, and `width: inherit` on `::after` means no icon. That makes the `@media ( hover: none )` block's `pointer-events: none` and `background-image: none` redundant, so it is removed.

`0px` cannot be shortened to `0`: it is invalid both inside `calc()` and as a colour-stop position. Hence the stylelint disable.

## Verification

Chromium against a local wiki, Citizen skin, on an overflowing tabber.

| | `hover: hover` | `hover: none` (device emulation, 390px) |
| --- | --- | --- |
| `--tabber-arrow-width` | `32px` | `0px` |
| button box | 32×42, hit-tests across full width | 0 wide; hit test at its position returns the tab behind |
| `::after` | 32px, glyph centred | 0px, no icon |
| mask | `transparent 32px, #000 20%, #000 80%, transparent calc(100% - 32px)` | `transparent 0px, #000 20%, #000 80%, transparent 100%` |

The touch mask is the original gradient — Chromium resolves `calc(100% - 0px)` to `100%`, and an omitted first stop already meant `0`. Confirmed pixel-for-pixel: six captures alternating the new mask against the original literal all hash identically, so **touch rendering is unchanged**.

Also checked the compiled output from `load.php`: `calc()` survives less.php unevaluated, the `@media ( hover: none )` block bubbles out after the base declaration so the override wins, and both intentional `pointer-events: none` rules (the arrow `::after` aria-hidden workaround, and `.tabber__indicator`) survive.

No JS change needed — `OVERFLOW_BUTTON_WIDTH_RATIO = 0.2` tracks the fade mask, not the button.

`npm run lint:styles` passes.

## Notes for review

- This makes `--tabber-arrow-width` a de facto public knob on `.tabber__header`. A wiki could set it to `24px`, or to a non-zero value under `hover: none` to force arrows on touch. Worth deciding whether to document it or treat it as internal.
- The enlarged arrow covers 32px of tab rather than 20px. That span is now fully masked, so it no longer looks clickable, but it is a larger invisible dead zone at the strip edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tab navigation arrow responsiveness across different devices.
  * Arrows remain available on hover-capable devices and collapse on touch-focused devices for a cleaner interface.
  * Updated tab header masking to adapt smoothly to the configured arrow width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->