### PR TITLE
fix: correct overflow scrolling, indicator and arrow keys under RTL

### DIFF
--- a/modules/ext.tabberNeue/createKeyboardNavigator.js
+++ b/modules/ext.tabberNeue/createKeyboardNavigator.js
@@ -5,6 +5,8 @@
  * @property {HTMLElement} tablist
  * @property {ArrayLike<HTMLElement>} tabs
  * @property {Function} onActivate called when the user moves focus via Home/End/Arrow keys.
+ * @property {boolean} [rtl=false] Direction of the tablist's own layout. Tabs
+ *   run right-to-left when set, so ArrowLeft advances and ArrowRight retreats.
  *
  * @typedef {Object} KeyboardNavigator
  * @property {Function} destroy
@@ -31,22 +33,23 @@ function createKeyboardNavigator( opts ) {
 		};
 	}
 	const onActivate = opts.onActivate;
+	const rtl = opts.rtl === true;
 	let tabFocus = 0;
 
-	function moveFocus( direction ) {
+	function moveFocus( step ) {
 		tabs[ tabFocus ].setAttribute( 'tabindex', '-1' );
 		const tabCount = tabs.length;
-		switch ( direction ) {
+		switch ( step ) {
 			case 'home':
 				tabFocus = 0;
 				break;
 			case 'end':
 				tabFocus = tabCount - 1;
 				break;
-			case 'right':
+			case 'next':
 				tabFocus = ( tabFocus + 1 ) % tabCount;
 				break;
-			case 'left':
+			case 'prev':
 				tabFocus = ( tabFocus - 1 + tabCount ) % tabCount;
 				break;
 			default:
@@ -61,8 +64,8 @@ function createKeyboardNavigator( opts ) {
 		const keyMap = {
 			Home: 'home',
 			End: 'end',
-			ArrowRight: 'right',
-			ArrowLeft: 'left'
+			ArrowRight: rtl ? 'prev' : 'next',
+			ArrowLeft: rtl ? 'next' : 'prev'
 		};
 		if ( keyMap[ e.key ] ) {
 			e.preventDefault();

--- a/modules/ext.tabberNeue/createOverflowController.js
+++ b/modules/ext.tabberNeue/createOverflowController.js
@@ -1,8 +1,6 @@
 const overflowMath = require( './overflowMath.js' );
 const { roundScrollLeft } = require( './domHelpers.js' );
 
-const OVERFLOW_BUTTON_WIDTH_RATIO = 0.2;
-
 /**
  * @typedef {Object} OverflowControllerOpts
  * @property {HTMLElement} tablist
@@ -13,6 +11,12 @@ const OVERFLOW_BUTTON_WIDTH_RATIO = 0.2;
  *   mode, where a single tab wider than the container still produces horizontal
  *   overflow (tabs are `white-space: nowrap`) but the arrows are meaningless
  *   because the tablist is not scrollable (`overflow: visible`).
+ * @property {boolean} [rtl=false] Direction of the tablist's own layout, which
+ *   is what decides the sign of scrollLeft. Injected rather than read from
+ *   getComputedStyle so the unit is testable against a plain-object tablist.
+ * @property {number} [arrowWidth=0] Width in px of each prev/next button, used
+ *   to keep a scrolled-to tab clear of the overlay. 0 reserves nothing, which
+ *   is correct wherever the arrows are absent.
  * @property {Function} [raf]
  *
  * @typedef {Object} OverflowController
@@ -33,19 +37,37 @@ function createOverflowController( opts ) {
 	const header = opts.header;
 	const animationsEnabled = opts.animationsEnabled !== false;
 	const enabled = opts.enabled !== false;
+	const rtl = opts.rtl === true;
+	const arrowWidth = opts.arrowWidth || 0;
 	const raf = opts.raf || window.requestAnimationFrame.bind( window );
 	let overflowing = false;
 
+	/**
+	 * @param {number} scrollLeft
+	 * @return {number} distance from the start edge, always >= 0 at rest.
+	 */
+	function toScrollDistance( scrollLeft ) {
+		return roundScrollLeft( rtl ? -scrollLeft : scrollLeft );
+	}
+
+	/**
+	 * @param {number} distance
+	 * @return {number} scrollLeft value to write.
+	 */
+	function toScrollLeft( distance ) {
+		return rtl ? 0 - distance : distance;
+	}
+
 	function getMetrics( tab ) {
 		const metrics = {
-			scrollLeft: roundScrollLeft( tablist.scrollLeft ),
+			scrollDistance: toScrollDistance( tablist.scrollLeft ),
 			scrollWidth: tablist.scrollWidth,
-			offsetWidth: tablist.offsetWidth,
-			clientWidth: tablist.clientWidth,
-			headerWidth: header.offsetWidth
+			clientWidth: tablist.clientWidth
 		};
 		if ( tab ) {
-			metrics.tabLeft = tab.offsetLeft;
+			metrics.tabStart = rtl ?
+				tablist.clientWidth - tab.offsetLeft - tab.offsetWidth :
+				tab.offsetLeft;
 			metrics.tabWidth = tab.offsetWidth;
 		}
 		return metrics;
@@ -80,12 +102,11 @@ function createOverflowController( opts ) {
 			return;
 		}
 		const metrics = getMetrics( tab );
-		const newScrollLeft = overflowMath.calculateNewScrollLeft(
-			metrics, OVERFLOW_BUTTON_WIDTH_RATIO
-		);
-		if ( newScrollLeft === null || newScrollLeft === metrics.scrollLeft ) {
+		const newDistance = overflowMath.calculateNewScrollDistance( metrics, arrowWidth );
+		if ( newDistance === null || newDistance === metrics.scrollDistance ) {
 			return;
 		}
+		const newScrollLeft = toScrollLeft( newDistance );
 		if ( animationsEnabled ) {
 			// Smooth scroll fires `scroll` events as it progresses; the caller's
 			// onTablistScroll handler will trigger update() during the animation.
@@ -97,12 +118,16 @@ function createOverflowController( opts ) {
 		}
 	}
 
+	/**
+	 * @param {number} offset Signed distance to travel, positive toward the end
+	 *   edge. Callers stay direction-agnostic; the sign is applied here.
+	 */
 	function scrollBy( offset ) {
-		const currentScroll = roundScrollLeft( tablist.scrollLeft );
-		const maxScroll = tablist.scrollWidth - tablist.offsetWidth;
-		const targetScroll = Math.min( Math.max( currentScroll + offset, 0 ), maxScroll );
+		const currentDistance = toScrollDistance( tablist.scrollLeft );
+		const maxDistance = tablist.scrollWidth - tablist.clientWidth;
+		const targetDistance = Math.min( Math.max( currentDistance + offset, 0 ), maxDistance );
 		raf( () => {
-			tablist.scrollLeft = targetScroll;
+			tablist.scrollLeft = toScrollLeft( targetDistance );
 		} );
 	}
 

--- a/modules/ext.tabberNeue/createTabber.js
+++ b/modules/ext.tabberNeue/createTabber.js
@@ -63,6 +63,11 @@ function createTabber( opts ) {
 	const section = element.querySelector( ':scope > .tabber__section' );
 	const panels = section.querySelectorAll( ':scope > .tabber__panel' );
 
+	const tablistStyle = win.getComputedStyle( tablist );
+	const rtl = tablistStyle.direction === 'rtl';
+	const arrowWidth =
+		parseFloat( tablistStyle.getPropertyValue( '--tabber-arrow-width' ) ) || 0;
+
 	// Build maps
 	const panelToTabMap = new WeakMap();
 	const panelIdToPanelMap = new Map();
@@ -195,14 +200,14 @@ function createTabber( opts ) {
 
 	// Compose units
 	units.overflow = createOverflowController( {
-		tablist, header, animationsEnabled, raf, enabled: !isWrap
+		tablist, header, animationsEnabled, raf, enabled: !isWrap, rtl, arrowWidth
 	} );
 	const debouncedUpdateOverflow = mwApi.util.debounce(
 		() => units.overflow.update(), 100
 	);
 
 	units.keyboard = createKeyboardNavigator( {
-		tablist, tabs,
+		tablist, tabs, rtl,
 		onActivate: ( tab ) => activate( tab, { source: 'user-keyboard' } )
 	} );
 
@@ -216,9 +221,9 @@ function createTabber( opts ) {
 		}
 		if ( isPointerDevice ) {
 			if ( e.target.closest( '.tabber__header__prev' ) ) {
-				units.overflow.scrollBy( -tablist.offsetWidth / 2 );
+				units.overflow.scrollBy( -tablist.clientWidth / 2 );
 			} else if ( e.target.closest( '.tabber__header__next' ) ) {
-				units.overflow.scrollBy( tablist.offsetWidth / 2 );
+				units.overflow.scrollBy( tablist.clientWidth / 2 );
 			}
 		}
 	}

--- a/modules/ext.tabberNeue/ext.tabberNeue.less
+++ b/modules/ext.tabberNeue/ext.tabberNeue.less
@@ -53,18 +53,18 @@
 		}
 
 		&--prev-visible .tabber__tabs {
-			-webkit-mask-image: linear-gradient( 90deg, transparent var( --tabber-arrow-width ), #000 20% );
-			mask-image: linear-gradient( 90deg, transparent var( --tabber-arrow-width ), #000 20% );
+			-webkit-mask-image: linear-gradient( to right, transparent var( --tabber-arrow-width ), #000 20% );
+			mask-image: linear-gradient( to right, transparent var( --tabber-arrow-width ), #000 20% );
 		}
 
 		&--next-visible .tabber__tabs {
-			-webkit-mask-image: linear-gradient( 90deg, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
-			mask-image: linear-gradient( 90deg, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
+			-webkit-mask-image: linear-gradient( to right, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
+			mask-image: linear-gradient( to right, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
 		}
 
 		&--prev-visible.tabber__header--next-visible .tabber__tabs {
-			-webkit-mask-image: linear-gradient( 90deg, transparent var( --tabber-arrow-width ), #000 20%, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
-			mask-image: linear-gradient( 90deg, transparent var( --tabber-arrow-width ), #000 20%, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
+			-webkit-mask-image: linear-gradient( to right, transparent var( --tabber-arrow-width ), #000 20%, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
+			mask-image: linear-gradient( to right, transparent var( --tabber-arrow-width ), #000 20%, #000 80%, transparent calc( 100% - var( --tabber-arrow-width ) ) );
 		}
 
 		&--prev-visible .tabber__header__prev,
@@ -105,6 +105,7 @@
 	&__indicator {
 		position: absolute;
 		bottom: 0;
+		/* @noflip */
 		left: 0;
 		height: 2px;
 		pointer-events: none;
@@ -127,8 +128,8 @@
 					display: block;
 					height: 0.5em;
 					margin-top: 1em;
-					background: #000;
-					background: linear-gradient( to right, var( --color-base, #202122 ) 8%, var( --color-subtle, #54595d ) 18%, var( --color-base, #202122 ) 33% );
+					background-color: #000;
+					background-image: linear-gradient( to right, var( --color-base, #202122 ) 8%, var( --color-subtle, #54595d ) 18%, var( --color-base, #202122 ) 33% );
 					border-radius: 40px;
 					animation-name: skeletonload;
 					animation-duration: 3s;

--- a/modules/ext.tabberNeue/overflowMath.js
+++ b/modules/ext.tabberNeue/overflowMath.js
@@ -2,20 +2,20 @@
  * Pure scroll math for the tabber overflow controller.
  * No DOM access, no globals, no mw — fully testable in isolation.
  *
+ * Offsets are distances from the start edge growing toward the end edge, not
+ * physical scrollLeft values, so the same arithmetic holds in both directions.
+ * createOverflowController normalises them.
+ *
  * @typedef {Object} OverflowMetrics
- * @property {number} scrollLeft
+ * @property {number} scrollDistance
  * @property {number} scrollWidth
- * @property {number} offsetWidth
  * @property {number} clientWidth
- * @property {number} headerWidth
  *
  * @typedef {Object} TabMetrics
- * @property {number} scrollLeft
+ * @property {number} scrollDistance
  * @property {number} scrollWidth
- * @property {number} offsetWidth
  * @property {number} clientWidth
- * @property {number} headerWidth
- * @property {number} tabLeft
+ * @property {number} tabStart
  * @property {number} tabWidth
  */
 
@@ -24,7 +24,7 @@
  * @return {boolean}
  */
 function isOverflowing( metrics ) {
-	return metrics.scrollWidth > metrics.offsetWidth;
+	return metrics.scrollWidth > metrics.clientWidth;
 }
 
 /**
@@ -32,7 +32,7 @@ function isOverflowing( metrics ) {
  * @return {boolean}
  */
 function isAtStart( metrics ) {
-	return metrics.scrollLeft <= 0;
+	return metrics.scrollDistance <= 0;
 }
 
 /**
@@ -40,36 +40,33 @@ function isAtStart( metrics ) {
  * @return {boolean}
  */
 function isAtEnd( metrics ) {
-	return metrics.scrollLeft + metrics.offsetWidth >= metrics.scrollWidth;
+	return metrics.scrollDistance + metrics.clientWidth >= metrics.scrollWidth;
 }
 
 /**
  * @param {TabMetrics} metrics — includes tab position (required).
- * @param {number} buttonWidthRatio — fraction of headerWidth occupied by each
- *   prev/next overflow button (0..1).
- * @return {number|null} new scrollLeft, or null if no scroll needed.
+ * @param {number} buttonWidth — width in px of each prev/next overflow button.
+ * @return {number|null} new scroll distance, or null if no scroll needed.
  */
-function calculateNewScrollLeft( metrics, buttonWidthRatio ) {
-	const buttonWidth = metrics.headerWidth * buttonWidthRatio;
-
-	const hasPrevButton = metrics.scrollLeft > 0;
+function calculateNewScrollDistance( metrics, buttonWidth ) {
+	const hasPrevButton = metrics.scrollDistance > 0;
 	const hasNextButton =
-		metrics.scrollLeft + metrics.clientWidth < metrics.scrollWidth;
+		metrics.scrollDistance + metrics.clientWidth < metrics.scrollWidth;
 
-	const visibleLeft = metrics.scrollLeft + ( hasPrevButton ? buttonWidth : 0 );
-	const visibleRight =
-		metrics.scrollLeft + metrics.clientWidth - ( hasNextButton ? buttonWidth : 0 );
+	const visibleStart = metrics.scrollDistance + ( hasPrevButton ? buttonWidth : 0 );
+	const visibleEnd =
+		metrics.scrollDistance + metrics.clientWidth - ( hasNextButton ? buttonWidth : 0 );
 
-	const tabLeft = metrics.tabLeft;
-	const tabRight = tabLeft + metrics.tabWidth;
+	const tabStart = metrics.tabStart;
+	const tabEnd = tabStart + metrics.tabWidth;
 
-	if ( tabLeft < visibleLeft ) {
-		return tabLeft - buttonWidth;
+	if ( tabStart < visibleStart ) {
+		return tabStart - buttonWidth;
 	}
-	if ( tabRight > visibleRight ) {
-		return tabRight - metrics.clientWidth + buttonWidth;
+	if ( tabEnd > visibleEnd ) {
+		return tabEnd - metrics.clientWidth + buttonWidth;
 	}
 	return null;
 }
 
-module.exports = { isOverflowing, isAtStart, isAtEnd, calculateNewScrollLeft };
+module.exports = { isOverflowing, isAtStart, isAtEnd, calculateNewScrollDistance };

--- a/tests/vitest/ext.tabberNeue/createKeyboardNavigator.test.js
+++ b/tests/vitest/ext.tabberNeue/createKeyboardNavigator.test.js
@@ -82,4 +82,28 @@ describe( 'createKeyboardNavigator', () => {
 		press( 'ArrowRight' );
 		expect( onActivate ).not.toHaveBeenCalled();
 	} );
+
+	describe( 'rtl', () => {
+		it( 'ArrowLeft advances to the next tab', () => {
+			createKeyboardNavigator( { tablist, tabs, onActivate, rtl: true } );
+			press( 'ArrowLeft' );
+			expect( tabs[ 1 ].getAttribute( 'tabindex' ) ).toBe( '0' );
+			expect( onActivate ).toHaveBeenCalledWith( tabs[ 1 ] );
+		} );
+
+		it( 'ArrowRight from index 0 wraps to last', () => {
+			createKeyboardNavigator( { tablist, tabs, onActivate, rtl: true } );
+			press( 'ArrowRight' );
+			expect( tabs[ 2 ].getAttribute( 'tabindex' ) ).toBe( '0' );
+			expect( onActivate ).toHaveBeenCalledWith( tabs[ 2 ] );
+		} );
+
+		it( 'leaves Home and End on their absolute ends', () => {
+			createKeyboardNavigator( { tablist, tabs, onActivate, rtl: true } );
+			press( 'End' );
+			expect( tabs[ 2 ].getAttribute( 'tabindex' ) ).toBe( '0' );
+			press( 'Home' );
+			expect( tabs[ 0 ].getAttribute( 'tabindex' ) ).toBe( '0' );
+		} );
+	} );
 } );

--- a/tests/vitest/ext.tabberNeue/createOverflowController.test.js
+++ b/tests/vitest/ext.tabberNeue/createOverflowController.test.js
@@ -9,7 +9,6 @@ describe( 'createOverflowController', () => {
 		return {
 			scrollLeft: opts.scrollLeft || 0,
 			scrollWidth: opts.scrollWidth || 100,
-			offsetWidth: opts.offsetWidth || 100,
 			clientWidth: opts.clientWidth || 100,
 			scrollTo: vi.fn()
 		};
@@ -21,6 +20,12 @@ describe( 'createOverflowController', () => {
 		return el;
 	}
 
+	function make( opts = {} ) {
+		return createOverflowController( Object.assign( {
+			tablist, header, animationsEnabled: false, raf: ( fn ) => fn()
+		}, opts ) );
+	}
+
 	beforeEach( () => {
 		tablist = makeTablist();
 		header = makeHeader();
@@ -29,37 +34,25 @@ describe( 'createOverflowController', () => {
 	describe( 'update', () => {
 		it( 'removes both visibility classes when not overflowing', () => {
 			header.classList.add( 'tabber__header--prev-visible', 'tabber__header--next-visible' );
-			tablist = makeTablist( { scrollWidth: 100, offsetWidth: 100 } );
-			const ctl = createOverflowController( {
-				tablist, header, animationsEnabled: false, raf: ( fn ) => fn()
-			} );
-			ctl.update();
+			tablist = makeTablist( { scrollWidth: 100, clientWidth: 100 } );
+			make().update();
 			expect( header.classList.contains( 'tabber__header--prev-visible' ) ).toBe( false );
 			expect( header.classList.contains( 'tabber__header--next-visible' ) ).toBe( false );
 		} );
 
 		it( 'shows next-visible when not at end', () => {
-			tablist = makeTablist(
-				{ scrollWidth: 500, offsetWidth: 200, clientWidth: 200, scrollLeft: 0 }
-			);
-			const ctl = createOverflowController( {
-				tablist, header, animationsEnabled: false, raf: ( fn ) => fn()
-			} );
-			ctl.update();
+			tablist = makeTablist( { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 } );
+			make().update();
 			expect( header.classList.contains( 'tabber__header--next-visible' ) ).toBe( true );
 			expect( header.classList.contains( 'tabber__header--prev-visible' ) ).toBe( false );
 		} );
 
 		it( 'never shows arrows when disabled, even with overflow metrics (wrap mode)', () => {
-			// A single over-wide tab makes scrollWidth > offsetWidth even in wrap
+			// A single over-wide tab makes scrollWidth > clientWidth even in wrap
 			// mode; the disabled controller must not surface the arrows/masks.
 			header.classList.add( 'tabber__header--next-visible' );
-			tablist = makeTablist(
-				{ scrollWidth: 500, offsetWidth: 200, clientWidth: 200, scrollLeft: 0 }
-			);
-			const ctl = createOverflowController( {
-				tablist, header, animationsEnabled: false, raf: ( fn ) => fn(), enabled: false
-			} );
+			tablist = makeTablist( { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 } );
+			const ctl = make( { enabled: false } );
 			ctl.update();
 			expect( header.classList.contains( 'tabber__header--next-visible' ) ).toBe( false );
 			expect( header.classList.contains( 'tabber__header--prev-visible' ) ).toBe( false );
@@ -67,79 +60,111 @@ describe( 'createOverflowController', () => {
 		} );
 
 		it( 'shows prev-visible when scrolled away from start', () => {
-			tablist = makeTablist(
-				{ scrollWidth: 500, offsetWidth: 200, clientWidth: 200, scrollLeft: 100 }
-			);
-			const ctl = createOverflowController( {
-				tablist, header, animationsEnabled: false, raf: ( fn ) => fn()
-			} );
-			ctl.update();
+			tablist = makeTablist( { scrollWidth: 500, clientWidth: 200, scrollLeft: 100 } );
+			make().update();
 			expect( header.classList.contains( 'tabber__header--prev-visible' ) ).toBe( true );
 			expect( header.classList.contains( 'tabber__header--next-visible' ) ).toBe( true );
+		} );
+
+		describe( 'rtl', () => {
+			// RTL scrollLeft runs [ -( scrollWidth - clientWidth ), 0 ], resting at 0.
+			it( 'shows only next-visible at the start', () => {
+				tablist = makeTablist( { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 } );
+				make( { rtl: true } ).update();
+				expect( header.classList.contains( 'tabber__header--next-visible' ) ).toBe( true );
+				expect( header.classList.contains( 'tabber__header--prev-visible' ) ).toBe( false );
+			} );
+
+			it( 'shows both when scrolled away from start', () => {
+				tablist = makeTablist( { scrollWidth: 500, clientWidth: 200, scrollLeft: -100 } );
+				make( { rtl: true } ).update();
+				expect( header.classList.contains( 'tabber__header--prev-visible' ) ).toBe( true );
+				expect( header.classList.contains( 'tabber__header--next-visible' ) ).toBe( true );
+			} );
+
+			it( 'shows only prev-visible at the end', () => {
+				tablist = makeTablist( { scrollWidth: 500, clientWidth: 200, scrollLeft: -300 } );
+				make( { rtl: true } ).update();
+				expect( header.classList.contains( 'tabber__header--prev-visible' ) ).toBe( true );
+				expect( header.classList.contains( 'tabber__header--next-visible' ) ).toBe( false );
+			} );
 		} );
 	} );
 
 	describe( 'scrollTabIntoView', () => {
 		it( 'is a no-op when not overflowing', () => {
-			tablist = makeTablist( { scrollWidth: 100, offsetWidth: 100 } );
-			const ctl = createOverflowController( {
-				tablist, header, animationsEnabled: false, raf: ( fn ) => fn()
-			} );
+			tablist = makeTablist( { scrollWidth: 100, clientWidth: 100 } );
+			const ctl = make( { arrowWidth: 40 } );
 			ctl.update(); // makes isOverflowing = false
 			ctl.scrollTabIntoView( { offsetLeft: 0, offsetWidth: 50 } );
 			expect( tablist.scrollTo ).not.toHaveBeenCalled();
 		} );
 
 		it( 'uses smooth scroll when animations enabled', () => {
-			tablist = makeTablist(
-				{ scrollWidth: 500, offsetWidth: 200, clientWidth: 200, scrollLeft: 0 }
-			);
-			const ctl = createOverflowController( {
-				tablist, header, animationsEnabled: true, raf: ( fn ) => fn()
-			} );
+			tablist = makeTablist( { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 } );
+			const ctl = make( { animationsEnabled: true, arrowWidth: 40 } );
 			ctl.update();
 			ctl.scrollTabIntoView( { offsetLeft: 250, offsetWidth: 50 } );
 			expect( tablist.scrollTo ).toHaveBeenCalledWith( { left: 140, behavior: 'smooth' } );
 		} );
 
 		it( 'writes scrollLeft directly when animations disabled', () => {
-			tablist = makeTablist(
-				{ scrollWidth: 500, offsetWidth: 200, clientWidth: 200, scrollLeft: 0 }
-			);
-			const ctl = createOverflowController( {
-				tablist, header, animationsEnabled: false, raf: ( fn ) => fn()
-			} );
+			tablist = makeTablist( { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 } );
+			const ctl = make( { arrowWidth: 40 } );
 			ctl.update();
 			ctl.scrollTabIntoView( { offsetLeft: 250, offsetWidth: 50 } );
 			expect( tablist.scrollLeft ).toBe( 140 );
 			expect( tablist.scrollTo ).not.toHaveBeenCalled();
 		} );
+
+		it( 'mirrors the tab offset and the written scrollLeft in rtl', () => {
+			// The rtl mirror of offsetLeft 250 / width 50 in a 200-wide viewport is
+			// tabStart = 200 - ( -100 ) - 50 = 250, the same distance as ltr above,
+			// so the same 140 comes back out — negated on write.
+			tablist = makeTablist( { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 } );
+			const ctl = make( { rtl: true, arrowWidth: 40 } );
+			ctl.update();
+			ctl.scrollTabIntoView( { offsetLeft: -100, offsetWidth: 50 } );
+			expect( tablist.scrollLeft ).toBe( -140 );
+		} );
 	} );
 
 	describe( 'scrollBy', () => {
-		it( 'clamps below 0 to 0', () => {
-			tablist = makeTablist( { scrollLeft: 50, scrollWidth: 500, offsetWidth: 200 } );
-			const ctl = createOverflowController( {
-				tablist, header, animationsEnabled: false, raf: ( fn ) => fn()
-			} );
-			ctl.scrollBy( -200 );
+		it( 'clamps below the start to 0', () => {
+			tablist = makeTablist( { scrollLeft: 50, scrollWidth: 500, clientWidth: 200 } );
+			make().scrollBy( -200 );
 			expect( tablist.scrollLeft ).toBe( 0 );
 		} );
 
-		it( 'clamps above max to max', () => {
-			tablist = makeTablist( { scrollLeft: 50, scrollWidth: 500, offsetWidth: 200 } );
-			const ctl = createOverflowController( {
-				tablist, header, animationsEnabled: false, raf: ( fn ) => fn()
-			} );
-			ctl.scrollBy( 1000 );
+		it( 'clamps beyond the end to max', () => {
+			tablist = makeTablist( { scrollLeft: 50, scrollWidth: 500, clientWidth: 200 } );
+			make().scrollBy( 1000 );
 			expect( tablist.scrollLeft ).toBe( 300 ); // 500 - 200
+		} );
+
+		describe( 'rtl', () => {
+			it( 'travels toward the end on a positive offset', () => {
+				tablist = makeTablist( { scrollLeft: -50, scrollWidth: 500, clientWidth: 200 } );
+				make( { rtl: true } ).scrollBy( 100 );
+				expect( tablist.scrollLeft ).toBe( -150 );
+			} );
+
+			it( 'clamps below the start to 0 without producing -0', () => {
+				tablist = makeTablist( { scrollLeft: -50, scrollWidth: 500, clientWidth: 200 } );
+				make( { rtl: true } ).scrollBy( -200 );
+				expect( tablist.scrollLeft ).toBe( 0 );
+				expect( Object.is( tablist.scrollLeft, -0 ) ).toBe( false );
+			} );
+
+			it( 'clamps beyond the end to negative max', () => {
+				tablist = makeTablist( { scrollLeft: -50, scrollWidth: 500, clientWidth: 200 } );
+				make( { rtl: true } ).scrollBy( 1000 );
+				expect( tablist.scrollLeft ).toBe( -300 );
+			} );
 		} );
 	} );
 
 	it( 'destroy() exists and does not throw', () => {
-		const ctl = createOverflowController( {
-			tablist, header, animationsEnabled: false, raf: ( fn ) => fn()
-		} );
-		expect( () => ctl.destroy() ).not.toThrow();
+		expect( () => make().destroy() ).not.toThrow();
 	} );
 } );

--- a/tests/vitest/ext.tabberNeue/createTabber.test.js
+++ b/tests/vitest/ext.tabberNeue/createTabber.test.js
@@ -60,6 +60,7 @@ describe( 'createTabber', () => {
 				mw,
 				window: Object.assign( {}, window, {
 					matchMedia: vi.fn().mockReturnValue( { matches: false } ),
+					getComputedStyle: window.getComputedStyle.bind( window ),
 					scrollBy: mockScrollBy
 				} ),
 				document,
@@ -416,7 +417,8 @@ describe( 'createTabber animation orchestration', () => {
 				config: { cdnMaxAge: 60, enableAnimation: true, updateLocationOnTabChange: true },
 				mw,
 				window: Object.assign( {}, window, {
-					matchMedia: vi.fn().mockReturnValue( { matches: false } )
+					matchMedia: vi.fn().mockReturnValue( { matches: false } ),
+					getComputedStyle: window.getComputedStyle.bind( window )
 				} ),
 				document,
 				IntersectionObserver: mockIO,

--- a/tests/vitest/ext.tabberNeue/overflowMath.test.js
+++ b/tests/vitest/ext.tabberNeue/overflowMath.test.js
@@ -1,80 +1,88 @@
-const { calculateNewScrollLeft, isOverflowing, isAtStart, isAtEnd } =
+const { calculateNewScrollDistance, isOverflowing, isAtStart, isAtEnd } =
 	require( '../../../modules/ext.tabberNeue/overflowMath.js' );
 
 describe( 'overflowMath', () => {
 	describe( 'isOverflowing', () => {
-		it( 'returns true when scrollWidth exceeds offsetWidth', () => {
-			expect( isOverflowing( { scrollWidth: 200, offsetWidth: 100 } ) ).toBe( true );
+		it( 'returns true when scrollWidth exceeds clientWidth', () => {
+			expect( isOverflowing( { scrollWidth: 200, clientWidth: 100 } ) ).toBe( true );
 		} );
 		it( 'returns false when content fits', () => {
-			expect( isOverflowing( { scrollWidth: 100, offsetWidth: 100 } ) ).toBe( false );
+			expect( isOverflowing( { scrollWidth: 100, clientWidth: 100 } ) ).toBe( false );
 		} );
 	} );
 
 	describe( 'isAtStart', () => {
-		it( 'returns true when scrollLeft is 0', () => {
-			expect( isAtStart( { scrollLeft: 0 } ) ).toBe( true );
+		it( 'returns true when at the start', () => {
+			expect( isAtStart( { scrollDistance: 0 } ) ).toBe( true );
 		} );
-		it( 'returns true when scrollLeft is negative (rubber-band)', () => {
-			expect( isAtStart( { scrollLeft: -3 } ) ).toBe( true );
+		it( 'returns true when overscrolled past the start (rubber-band)', () => {
+			expect( isAtStart( { scrollDistance: -3 } ) ).toBe( true );
 		} );
 		it( 'returns false when scrolled', () => {
-			expect( isAtStart( { scrollLeft: 50 } ) ).toBe( false );
+			expect( isAtStart( { scrollDistance: 50 } ) ).toBe( false );
 		} );
 	} );
 
 	describe( 'isAtEnd', () => {
 		it( 'returns true when scrolled to the end', () => {
-			const m = { scrollLeft: 100, offsetWidth: 100, scrollWidth: 200 };
+			const m = { scrollDistance: 100, clientWidth: 100, scrollWidth: 200 };
 			expect( isAtEnd( m ) ).toBe( true );
 		} );
-		it( 'returns false when more content is to the right', () => {
-			const m = { scrollLeft: 50, offsetWidth: 100, scrollWidth: 200 };
+		it( 'returns false when more content remains', () => {
+			const m = { scrollDistance: 50, clientWidth: 100, scrollWidth: 200 };
 			expect( isAtEnd( m ) ).toBe( false );
 		} );
 	} );
 
-	describe( 'calculateNewScrollLeft', () => {
-		const buttonWidthRatio = 0.2;
+	describe( 'calculateNewScrollDistance', () => {
+		const buttonWidth = 60;
 
 		it( 'returns null when tab is already in visible area', () => {
 			const metrics = {
-				scrollLeft: 0, scrollWidth: 500, offsetWidth: 300, clientWidth: 300,
-				headerWidth: 300, tabLeft: 100, tabWidth: 50
+				scrollDistance: 0, scrollWidth: 500, clientWidth: 300,
+				tabStart: 100, tabWidth: 50
 			};
-			expect( calculateNewScrollLeft( metrics, buttonWidthRatio ) ).toBeNull();
+			expect( calculateNewScrollDistance( metrics, buttonWidth ) ).toBeNull();
 		} );
 
-		it( 'scrolls left to expose tab hidden behind prev button', () => {
+		it( 'scrolls back to expose tab hidden behind prev button', () => {
 			const metrics = {
-				scrollLeft: 100, scrollWidth: 500, offsetWidth: 300, clientWidth: 300,
-				headerWidth: 300, tabLeft: 110, tabWidth: 50
+				scrollDistance: 100, scrollWidth: 500, clientWidth: 300,
+				tabStart: 110, tabWidth: 50
 			};
-			// buttonWidth = 60. visibleLeft = 100 + 60 = 160. tabLeft 110 < 160.
-			// returns tabLeft - buttonWidth = 110 - 60 = 50.
-			expect( calculateNewScrollLeft( metrics, buttonWidthRatio ) ).toBe( 50 );
+			// visibleStart = 100 + 60 = 160. tabStart 110 < 160.
+			// returns tabStart - buttonWidth = 110 - 60 = 50.
+			expect( calculateNewScrollDistance( metrics, buttonWidth ) ).toBe( 50 );
 		} );
 
-		it( 'scrolls right to expose tab hidden behind next button', () => {
+		it( 'scrolls on to expose tab hidden behind next button', () => {
 			const metrics = {
-				scrollLeft: 0, scrollWidth: 500, offsetWidth: 300, clientWidth: 300,
-				headerWidth: 300, tabLeft: 250, tabWidth: 50
+				scrollDistance: 0, scrollWidth: 500, clientWidth: 300,
+				tabStart: 250, tabWidth: 50
 			};
-			// hasNextButton = true (300 < 500). buttonWidth = 60.
-			// visibleRight = 0 + 300 - 60 = 240. tabRight 300 > 240.
-			// returns tabRight - clientWidth + buttonWidth = 300 - 300 + 60 = 60.
-			expect( calculateNewScrollLeft( metrics, buttonWidthRatio ) ).toBe( 60 );
+			// hasNextButton = true (300 < 500).
+			// visibleEnd = 0 + 300 - 60 = 240. tabEnd 300 > 240.
+			// returns tabEnd - clientWidth + buttonWidth = 300 - 300 + 60 = 60.
+			expect( calculateNewScrollDistance( metrics, buttonWidth ) ).toBe( 60 );
 		} );
 
 		it( 'does not subtract prev-button width when at the start', () => {
 			const metrics = {
-				scrollLeft: 0, scrollWidth: 500, offsetWidth: 300, clientWidth: 300,
-				headerWidth: 300, tabLeft: 10, tabWidth: 50
+				scrollDistance: 0, scrollWidth: 500, clientWidth: 300,
+				tabStart: 10, tabWidth: 50
 			};
-			// hasPrevButton = false. visibleLeft = 0. tabLeft 10 not < 0.
-			// hasNextButton = true. visibleRight = 240. tabRight 60 not > 240.
-			// → null
-			expect( calculateNewScrollLeft( metrics, buttonWidthRatio ) ).toBeNull();
+			// hasPrevButton = false. visibleStart = 0. tabStart 10 not < 0.
+			// hasNextButton = true. visibleEnd = 240. tabEnd 60 not > 240.
+			expect( calculateNewScrollDistance( metrics, buttonWidth ) ).toBeNull();
+		} );
+
+		it( 'reserves nothing when there are no arrows', () => {
+			const metrics = {
+				scrollDistance: 0, scrollWidth: 500, clientWidth: 300,
+				tabStart: 250, tabWidth: 50
+			};
+			// visibleEnd = 300. tabEnd 300 not > 300.
+			expect( calculateNewScrollDistance( metrics, 0 ) ).toBeNull();
 		} );
 	} );
 } );

--- a/tests/vitest/ext.tabberNeue/tabberRegistry.test.js
+++ b/tests/vitest/ext.tabberNeue/tabberRegistry.test.js
@@ -34,6 +34,7 @@ describe( 'tabberRegistry', () => {
 		MockRO = buildMockRO( resizeObservers );
 		win = Object.assign( {}, window, {
 			matchMedia: vi.fn().mockReturnValue( { matches: false } ),
+			getComputedStyle: window.getComputedStyle.bind( window ),
 			history: window.history,
 			location: { hash: '', pathname: '/wiki/Foo', search: '' },
 			addEventListener: vi.fn(),


### PR DESCRIPTION
An RTL scroll container reports `scrollLeft` in the range `[-(scrollWidth - clientWidth), 0]`, resting at 0. The overflow subsystem assumed the LTR `0..max` range throughout.

Measured on an overflowing tabber (`scrollWidth 983`, `clientWidth 852`, RTL range `[-131, 0]`):

| | before | after |
| --- | --- | --- |
| `isAtStart` at the far end | `true` — prev arrow never appears | `false` |
| `isAtEnd` at the far end | `false` — next arrow never hides | `true` |
| "next" click from rest | target `131` → **actual `0`, dead** | `0 → -131` |
| "prev" click from the end | collapses to `0`, over-scrolls | `-131 → 0` |

## Approach

`scrollLeft` is normalised to a **distance from the start edge** at the one point where the controller touches the DOM, and converted back on write. `overflowMath` then has no notion of direction at all — which is why `calculateNewScrollDistance` keeps its shape. Mirroring a tab's `offsetLeft` into the same space maps the measured RTL offsets `[251, -321, -383]` onto the LTR `[0, 349, 921]` exactly.

Direction is read once from the tablist's own computed style — the **content** direction, deliberately not the **interface** direction CSSJanus keys the stylesheet off. The two diverge when an RTL interface renders LTR content. It is passed in as an option rather than read inside the units, because `getComputedStyle` throws on the plain-object tablist fixture the tests use.

## Three more RTL defects from the same audit

- **Edge masks** used `linear-gradient( 90deg, … )`. CSSJanus flips `left`/`right` keywords but has no angle handling, so the fade landed on the opposite edge from the arrow it exists to soften. `to right` flips *with* the buttons, keeping mask and arrow on the same edge. `:dir()` would have been wrong here — it would key masks to content direction while the buttons stay on interface direction.
- **`.tabber__indicator`** was anchored `left: 0`, which CSSJanus rewrote to `right: 0` while `createTabIndicator` kept positioning it with a physical `translateX( offsetLeft )`. The two disagreed by `clientWidth - tabWidth`. `@noflip` keeps both physical. **This was visible well beyond RTL wikis** — any RTL interface language over LTR content (e.g. `?uselang=he`) displaced the indicator on every tabber on the page.
- **Skeleton loader** used the `background` shorthand, so CSSJanus rewrote its first colour stop from `8%` to `92%`. The stops resolved non-monotonically and the shimmer collapsed to a flat bar.

Arrow keys now resolve to a logical next/prev, so ArrowLeft advances in an RTL tablist. Scroll-into-view clearance comes from `--tabber-arrow-width` rather than a `0.2` ratio of the header, which reserved ~151px for a 32px arrow — and resolves to 0 wherever the arrows are absent.

## Deliberately not changed

`section.scrollLeft = panel.offsetLeft` is **already correct** in RTL: `offsetLeft` and `scrollLeft` go negative together, so every write lands exactly (measured: panel offsets `[0, -852, -1704]`, range `[-1704, 0]`). "Fixing" it would break panel switching.

The panel/view-transition animations are also correct in RTL by a double flip — CSSJanus flips `animation-name` identifiers containing left/right *and* sign-flips `translateX()` in the keyframes, and the two cancel. Left alone.

## Verification

156 tests pass, including new RTL coverage for the controller's class toggling, `scrollBy` clamping in both directions, the mirrored scroll-into-view, and the arrow-key mapping.

Verified in Chromium against a local wiki in the true RTL config (RTL stylesheet via `uselang=he` **and** RTL content direction):

- states across the range: at rest → `--next-visible` only; mid → both; at end → `--prev-visible` only
- arrows: NEXT `0 → -131`, PREV `-131 → 0`
- prev button 32px, flush at the **right** edge when scrolled (correct for RTL)
- indicator vs active tab: `deltaX 0, deltaW 0`
- mask resolves to `linear-gradient(to left, transparent 32px, …)`

LTR re-checked for regression: NEXT click `0 → 131`, at end `--prev-visible` only, indicator delta `[0, 0]`.

Served CSS diffed LTR vs RTL to confirm CSSJanus behaviour: masks now flip `to right`→`to left` with stops preserved; the indicator stays `left: 0` in both; skeleton stops stay `8%, 18%, 33%` in both.

## Note for review

`.phpactor.json` in the repo root breaks `npm run lint` locally — it is untracked and globally gitignored, so the JSON lint glob picks up whatever the developer has there. `lint:js`, `lint:styles`, `lint:i18n` and the tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)